### PR TITLE
Feature/#1 media query utils 추가

### DIFF
--- a/src/utils/hooks/useMediaQuery.ts
+++ b/src/utils/hooks/useMediaQuery.ts
@@ -1,0 +1,24 @@
+import { useEffect, useState } from 'react';
+
+const MOBILE_MEDIA_QUERY = '(max-width: 576px)';
+
+const useMediaQuery = () => {
+  const [state, setState] = useState({
+    windowWidth: window.innerWidth,
+    isMobile: window.matchMedia(MOBILE_MEDIA_QUERY).matches,
+  });
+
+  useEffect(() => {
+    const resizeHandler = () => {
+      const currentWindowWidth = window.innerWidth;
+      const isMobile = window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+      setState({ windowWidth: currentWindowWidth, isMobile });
+    };
+    window.addEventListener('resize', resizeHandler);
+    return () => window.removeEventListener('resize', resizeHandler);
+  }, [state.windowWidth]);
+
+  return state.isMobile;
+};
+
+export default useMediaQuery;

--- a/src/utils/hooks/useMediaQuery.ts
+++ b/src/utils/hooks/useMediaQuery.ts
@@ -1,24 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 const MOBILE_MEDIA_QUERY = '(max-width: 576px)';
 
-const useMediaQuery = () => {
-  const [state, setState] = useState({
-    windowWidth: window.innerWidth,
-    isMobile: window.matchMedia(MOBILE_MEDIA_QUERY).matches,
-  });
+export default function useMediaQuery() {
+  const [matches, setMatches] = useState(() => window.matchMedia(MOBILE_MEDIA_QUERY).matches);
+  const matchMediaRef = useRef<MediaQueryList | null>(null);
 
   useEffect(() => {
-    const resizeHandler = () => {
-      const currentWindowWidth = window.innerWidth;
-      const isMobile = window.matchMedia(MOBILE_MEDIA_QUERY).matches;
-      setState({ windowWidth: currentWindowWidth, isMobile });
+    const matchMedia = window.matchMedia(MOBILE_MEDIA_QUERY);
+    matchMediaRef.current = matchMedia;
+    function handleChange() {
+      setMatches(window.matchMedia(MOBILE_MEDIA_QUERY).matches);
+    }
+    handleChange();
+    matchMediaRef?.current.addEventListener('change', handleChange);
+
+    return () => {
+      matchMediaRef.current?.removeEventListener('change', handleChange);
     };
-    window.addEventListener('resize', resizeHandler);
-    return () => window.removeEventListener('resize', resizeHandler);
-  }, [state.windowWidth]);
 
-  return state.isMobile;
-};
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
-export default useMediaQuery;
+  return { isMobile: matches };
+}

--- a/src/utils/styles/mediaQuery.scss
+++ b/src/utils/styles/mediaQuery.scss
@@ -1,0 +1,13 @@
+$media: (
+  mobile: 576px,
+);
+
+@mixin media-breakpoint($breakpoint) {
+  @each $breakpointName, $size in $media {
+    @if $breakpoint == $breakpointName {
+      @media screen and (max-width: $size) {
+        @content;
+      }
+    }
+  }
+}

--- a/src/utils/styles/mediaQuery.scss
+++ b/src/utils/styles/mediaQuery.scss
@@ -1,13 +1,45 @@
+@use "sass:map";
+
 $media: (
   mobile: 576px,
 );
 
-@mixin media-breakpoint($breakpoint) {
-  @each $breakpointName, $size in $media {
-    @if $breakpoint == $breakpointName {
-      @media screen and (max-width: $size) {
-        @content;
-      }
+/*
+  by Bootstrap
+  https://github.com/twbs/bootstrap/blob/main/scss/mixins/_breakpoints.scss
+*/
+@mixin media-breakpoint-up($name, $breakpoints: $media) {
+  $min: breakpoint-min($name, $breakpoints);
+
+  @if $min {
+    @media (min-width: $min) {
+      @content;
     }
+  } @else {
+    @content;
   }
+}
+
+@mixin media-breakpoint-down($name, $breakpoints: $media) {
+  $max: breakpoint-max($name, $breakpoints);
+
+  @if $max {
+    @media (max-width: $max) {
+      @content;
+    }
+  } @else {
+    @content;
+  }
+}
+
+@function breakpoint-min($name, $breakpoints: $media) {
+  $min: map.get($breakpoints, $name);
+
+  @return if($min != 0, $min, null);
+}
+
+@function breakpoint-max($name, $breakpoints: $media) {
+  $max: map.get($breakpoints, $name);
+
+  @return if($max and $max > 0, $max - 0.02, null);
 }


### PR DESCRIPTION
## #1 request

반응형을 위한 media-query를 관리하는 utils를 추가했습니다.
- 모바일 여부를 반환하는 useMediaQuery hook
- media-breakpoint를 쉽게 사용하기 위한 mixin

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot
![responsive](https://user-images.githubusercontent.com/50780281/188569293-9c3e4f2e-f101-4a6f-b966-5c3d05b96720.gif)
