### PR TITLE
#13 폰트 로딩 불가

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -1,4 +1,4 @@
 @use "../utils/styles/mixin/index";
-@include index.font-face("SUIT", "/assets/fonts/SUIT-Regular", "400");
-@include index.font-face("SUIT", "/assets/fonts/SUIT-Medium", "500");
-@include index.font-face("SUIT", "/assets/fonts/SUIT-Bold", "700");
+@include index.font-face("SUIT", "/assets/fonts/SUIT-Regular", 400);
+@include index.font-face("SUIT", "/assets/fonts/SUIT-Medium", 500);
+@include index.font-face("SUIT", "/assets/fonts/SUIT-Bold", 700);


### PR DESCRIPTION
## #13  request

* SUIT-Bold를 제외한 나머지 폰트가 로드되지 않는 버그 수정.
* default 폰트를 SUIT-Regular로 수정

## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes


### Screenshot
![스크린샷 2022-09-16 오후 10 15 25](https://user-images.githubusercontent.com/51052049/190647561-18b3c142-a27e-4137-81ce-367458d7523e.png)
* 다음과 같이 기본적으로 SUIT-Regular만 포함됩니다.

![스크린샷 2022-09-16 오후 10 15 41](https://user-images.githubusercontent.com/51052049/190647720-349a16a0-22a4-40a5-bc23-fbb80a8184e9.png)
* 다음과 같이 다른 font-weight를 추가하게 되면 다른 font-weight파일이 추가적으로 포함됩니다.
