### PR TITLE
Feature/#12 user apiClient, 타입 interface 정의

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "@types/node": "^16.7.13",
     "@types/react": "^18.0.0",
     "@types/react-dom": "^18.0.0",
+    "axios": "^0.27.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^3.39.1",

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,1 @@
+export * as user from './user';

--- a/src/api/user/entity.ts
+++ b/src/api/user/entity.ts
@@ -1,0 +1,33 @@
+export interface ILoginResponse {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface IRefreshResponse extends ILoginResponse {}
+
+export interface ILoginParams {
+  accound: string;
+  password: string;
+}
+
+export interface IRegisterParams extends ILoginParams {
+  email: string;
+}
+
+export interface IModifyParams {
+  nickname?: string;
+  password?: string;
+  email?: string;
+}
+
+export interface IUser {
+  account: string;
+  nickname: string;
+  email: string;
+  id: number;
+  // 아래 두 파라미터도 확실한 도메인이 정해지면 수정 필요.
+  // oauthType = 'KAKAO' | 'NAVER' | 'GOOGLE'...
+  // userType = 'ADMIN' | 'NORMAL'...
+  oauthType: string;
+  userType: string;
+}

--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -1,0 +1,12 @@
+import userApi from './userApiClient';
+import {
+  ILoginParams, ILoginResponse, IModifyParams, IRegisterParams, IUser,
+} from './entity';
+
+export const register = (param: IRegisterParams) => userApi.post<IUser>('/', param);
+
+export const login = (param: ILoginParams) => userApi.post<ILoginResponse>('/login', param);
+
+export const getMe = () => userApi.get<IUser>('/me');
+
+export const modify = (param: IModifyParams) => userApi.patch<IUser>('/modify', param);

--- a/src/api/user/userApiClient.ts
+++ b/src/api/user/userApiClient.ts
@@ -1,0 +1,43 @@
+import axios from 'axios';
+import { IRefreshResponse } from './entity';
+
+const API_PATH = process.env.REACT_APP_API_PATH!;
+const accessToken = sessionStorage.getItem('accessToken');
+
+const userApi = axios.create({
+  baseURL: `${API_PATH}/user`,
+  headers: accessToken
+    ? { authorization: accessToken }
+    : { 'Content-type': 'application/json' },
+  timeout: 2000,
+});
+
+// TODO: refreshToken을 담는 로직이 필요. 아직 API에 body인지 header인지 미정인 상태.
+// 사이클 방지 및 refresh를 사용할 곳이 여기뿐이라 이곳에서 정의.
+const refreshAccessToken = () => userApi.post<IRefreshResponse>('/refresh')
+  .then((res) => {
+    sessionStorage.setItem('accessToken', res.data.accessToken);
+    localStorage.setItem('refreshToken', res.data.refreshToken);
+  })
+  .catch(() => {
+    localStorage.removeItem('refreshToken');
+    sessionStorage.removeItem('accessToken');
+  });
+
+// App단에서 'user/me' 호출할 때 accessToken을 갱신하므로 userApi에 종속.
+userApi.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    const errorCode = error.response.data.code;
+    // TODO: 백엔드단에서 정확한 토큰 인증 오류 시 코드/메시지를 정해주면 수정 필요.
+    if (errorCode > 400 && !originalRequest.retry) {
+      originalRequest.retry = true;
+      await refreshAccessToken();
+      return userApi(originalRequest);
+    }
+    return Promise.reject(error);
+  },
+);
+
+export default userApi;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,17 +2,33 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.scss';
 import { BrowserRouter } from 'react-router-dom';
+import { QueryClient, QueryClientProvider } from 'react-query';
 import App from './App';
 import reportWebVitals from './reportWebVitals';
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      refetchOnWindowFocus: false,
+      refetchOnMount: false,
+      refetchOnReconnect: false,
+      retry: 1,
+      staleTime: 5 * 60 * 1000,
+    },
+  },
+});
 
 const root = ReactDOM.createRoot(
   document.getElementById('root') as HTMLElement,
 );
+
 root.render(
   <React.StrictMode>
-    <BrowserRouter>
-      <App />
-    </BrowserRouter>
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>
+        <App />
+      </BrowserRouter>
+    </QueryClientProvider>
   </React.StrictMode>,
 );
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,6 @@ const queryClient = new QueryClient({
       refetchOnMount: false,
       refetchOnReconnect: false,
       retry: 1,
-      staleTime: 5 * 60 * 1000,
     },
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2614,6 +2614,14 @@ axe-core@^4.4.2:
   resolved "https://registry.yarnpkg.com/axe-core/-/axe-core-4.4.2.tgz#dcf7fb6dea866166c3eab33d68208afe4d5f670c"
   integrity sha512-LVAaGp/wkkgYJcjmHsoKx4juT1aQvJyPcW09MLCjVTh3V2cc6PnyempiLMNH5iMdfIX/zdbjUx2KDjMLCTdPeA==
 
+axios@^0.27.2:
+  version "0.27.2"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.27.2.tgz#207658cc8621606e586c85db4b41a750e756d972"
+  integrity sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==
+  dependencies:
+    follow-redirects "^1.14.9"
+    form-data "^4.0.0"
+
 axobject-query@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
@@ -4493,6 +4501,11 @@ follow-redirects@^1.0.0:
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.1.tgz#0ca6a452306c9b276e4d3127483e29575e207ad5"
   integrity sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==
 
+follow-redirects@^1.14.9:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 fork-ts-checker-webpack-plugin@^6.5.0:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-6.5.2.tgz#4f67183f2f9eb8ba7df7177ce3cf3e75cdafb340"
@@ -4516,6 +4529,15 @@ form-data@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-3.0.1.tgz#ebd53791b78356a99af9a300d4282c4d5eb9755f"
   integrity sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
   dependencies:
     asynckit "^0.4.0"
     combined-stream "^1.0.8"


### PR DESCRIPTION
## #12 request

- `user-controller`를 위한 userApiClient를 구현했습니다
  - `axios interceptor`를 활용해 accessToken을 재발급받을 수 있도록 구현했습니다.
- accessToken의 만료기간은 2일, refreshToken의 만료기간은 14일입니다.
  - accessToken은 sessionStorage에 저장했으며, 세션이 초기화되더라도 localStoarge에 저장한 refreshToken으로 재발급받습니다.
  - refreshToken도 만료되었다면, 각 스토리지를 초기화합니다.
- login, logout등의 동작은 먼저 완성될 #2 병합 이후 `react-query`로 custom hook을 만들어 예제를 작성할 예정입니다.
- user 관련 타입들을 `entity.ts` 파일에 정의했습니다.
- baseUrl에 `.env` 파일을 사용합니다. 스웨거에서 사용하는 API 링크를 사용하지만, 추후 문서화가 필요해보입니다. 
## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes
