### PR TITLE
Feature/#8 웹폰트 로드 중 텍스트 표시 속성 추가

### DIFF
--- a/src/utils/styles/mixin/index.scss
+++ b/src/utils/styles/mixin/index.scss
@@ -31,5 +31,6 @@
     src: string.unquote($font-source);
     font-style: $style;
     font-weight: $weight;
+    font-display: swap;
   }
 }


### PR DESCRIPTION
## #8  request

[https://web.dev/i18n/ko/font-display/](폰트 로드 중에도 텍스트를 계속 표시)하기 위한 속성을 추가했습니다.
* font-face의 mixin에 `font-display: swap` 추가


## Please check if the PR fulfills these requirements

- [ ] It's submitted to `develop` branch, __not__ the `main` branch
- [ ] The commit message follows our guidelines
- [ ] There are no warning message when you run `yarn lint`
- [ ] Docs updated for breaking changes


### Screenshot