### PR TITLE
Fix eslint 에서 require-default-props rule 끄기

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,7 +26,8 @@
 	],
 	"rules": {
 		"react/react-in-jsx-scope": "off",
-		"react/jsx-props-no-spreading": "off"
+		"react/jsx-props-no-spreading": "off",
+		"react/require-default-props": "off"
 	},
 	"settings": {
 		"import/resolver": {


### PR DESCRIPTION
## [no issue number] 

함수형 컴포넌트에서 defaultProps 를 사용하는 것은 [deprecated 될 예정입니다.](https://twitter.com/dan_abramov/status/1133878326358171650?s=20&t=2wzeT0xQI0T3l_hXAXLGWw)

이를 강제하는 lint rule 을 제거합니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot