### PR TITLE
Feature/#39 [Auth] 회원가입 기능 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "react-scripts": "5.0.1",
     "react-toastify": "^9.0.8",
     "sass": "^1.54.4",
-    "sha256": "^0.2.0",
     "tui-editor-plugin-font-size": "^1.0.4",
     "typescript": "^4.4.2",
     "web-vitals": "^2.1.0"

--- a/src/api/user/entity.ts
+++ b/src/api/user/entity.ts
@@ -14,6 +14,10 @@ export interface RegisterParams extends LoginParams {
   email: string;
 }
 
+export interface CheckIdDuplicateParams {
+  account: string;
+}
+
 export interface ModifyParams {
   nickname?: string;
   password?: string;

--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -1,10 +1,13 @@
 import makeToast from 'utils/ts/makeToast';
 import userApi from './userApiClient';
 import {
+  CheckIdDuplicateParams,
   LoginParams, LoginResponse, ModifyParams, RegisterParams, User,
 } from './entity';
 
 export const register = (param: RegisterParams) => userApi.post<User>('/', param);
+
+export const checkIdDuplicate = (param: CheckIdDuplicateParams) => userApi.get<User>(`/exists?account=${param.account}`);
 
 export const login = async (param: LoginParams) => {
   try {

--- a/src/api/user/userApiClient.ts
+++ b/src/api/user/userApiClient.ts
@@ -49,12 +49,12 @@ userApi.interceptors.response.use(
 
       // TODO: 백엔드단에서 정확한 토큰 인증 오류 시 코드/메시지를 정해주면 수정 필요.
       if (originalRequest.url !== '/refresh') {
-        return refreshAccessToken().then(() => userApi(originalRequest));
+        refreshAccessToken().then(() => userApi(originalRequest));
       }
-      return Promise.reject();
+      return Promise.reject(error);
     } catch {
       makeToast('error', '네트워크 오류가 발생했습니다.');
-      return Promise.reject();
+      return Promise.reject(error);
     }
   },
 );

--- a/src/pages/Auth/Login/index.tsx
+++ b/src/pages/Auth/Login/index.tsx
@@ -7,7 +7,6 @@ import AuthTitle from 'components/Auth/AuthTitle';
 import Copyright from 'components/Auth/Copyright';
 import cn from 'utils/ts/classNames';
 import { login } from 'api/user';
-import sha256 from 'sha256';
 import { useUpdateAuth } from 'store/auth';
 import styles from './Login.module.scss';
 
@@ -24,7 +23,7 @@ const useLoginRequest = () => {
   const submitLogin = async ({ id, password, isAutoLoginChecked }: LoginFormInput) => {
     const { data } = await login({
       account: id,
-      password: sha256(password),
+      password,
     });
 
     sessionStorage.setItem('accessToken', data.accessToken);

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -9,7 +9,7 @@ import styles from '../SignUp.module.scss';
 import { SignUpFormData } from '../entity';
 
 const useIdCheckServer = (id: string) => {
-  const { status } = useQuery(['idDuplicate', id], () => checkIdDuplicate({ account: id }), {
+  const { status } = useQuery(['idDuplicate', id], ({ queryKey: [, account] }) => checkIdDuplicate({ account }), {
     enabled: id !== '',
   });
 

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -18,9 +18,8 @@ const useIdCheckServer = (id: string) => {
 
 const useIdDuplicateCheck = () => {
   const [currentCheckedId, setCurrentCheckedId] = useState('');
-  const { getValues } = useFormContext<SignUpFormData>();
+  const { getValues, trigger } = useFormContext<SignUpFormData>();
   const id = getValues('id');
-  const { trigger } = useFormContext<SignUpFormData>();
 
   const handleCheckIdDuplicate = () => {
     setCurrentCheckedId(id);

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -1,13 +1,43 @@
-import React from 'react';
+import { useEffect, useState } from 'react';
 import cn from 'utils/ts/classNames';
 import { ReactComponent as ErrorIcon } from 'assets/svg/auth/error.svg';
 import { useFormContext } from 'react-hook-form';
+import { useQuery } from 'react-query';
+import { checkIdDuplicate } from 'api/user';
 import { ERROR_MESSAGE } from '../../static/signUp';
 import styles from '../SignUp.module.scss';
 import { SignUpFormData } from '../entity';
 
+const useIdCheckServer = (id: string) => {
+  const { status } = useQuery(['idDuplicate', id], () => checkIdDuplicate({ account: id }), {
+    enabled: id !== '',
+  });
+
+  return status;
+};
+
+const useIdDuplicateCheck = () => {
+  const [currentCheckedId, setCurrentCheckedId] = useState('');
+  const { getValues } = useFormContext<SignUpFormData>();
+  const id = getValues('id');
+  const { trigger } = useFormContext<SignUpFormData>();
+
+  const handleCheckIdDuplicate = () => {
+    setCurrentCheckedId(id);
+  };
+
+  const status = useIdCheckServer(currentCheckedId);
+
+  useEffect(() => {
+    if (id && (id === currentCheckedId)) trigger('id');
+  }, [trigger, currentCheckedId, id, status]);
+
+  return { status, handleCheckIdDuplicate, currentCheckedId };
+};
+
 export default function IdInput() {
   const { register, watch, formState: { errors } } = useFormContext<SignUpFormData>();
+  const { status, handleCheckIdDuplicate, currentCheckedId } = useIdDuplicateCheck();
 
   return (
     <div className={styles.form__form}>
@@ -33,7 +63,13 @@ export default function IdInput() {
           [styles['form__input--error']]: errors?.id !== undefined,
         })}
         // TODO: 아이디 중복확인 기능
-        {...register('id', { required: ERROR_MESSAGE.id })}
+        {...register('id', {
+          required: ERROR_MESSAGE.id,
+          validate: {
+            checkError: () => ((status !== 'error') || '이미 사용중인 아이디입니다.'),
+            checkValid: (val) => ((status === 'success' && val === currentCheckedId) || '아이디 중복확인을 해주세요.'),
+          },
+        })}
       />
       <button
         type="button"
@@ -42,11 +78,10 @@ export default function IdInput() {
           [styles['form__id-check-button--active']]: watch('id') !== '',
           [styles['form__id-check-button--error']]: errors?.id !== undefined,
         })}
-        disabled={errors?.id !== undefined}
+        onClick={handleCheckIdDuplicate}
       >
-        중복 확인
+        {status === 'loading' ? '확인중..' : '중복 확인'}
       </button>
     </div>
-
   );
 }

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -68,6 +68,7 @@ export default function IdInput() {
           validate: {
             checkValid: (val) => ((val === currentCheckedId) || '아이디 중복확인을 해주세요.'),
             checkError: () => ((status !== 'error') || '이미 사용중인 아이디입니다.'),
+            checkLoading: () => ((status !== 'loading') || '중복 확인중입니다.'),
           },
         })}
       />
@@ -80,7 +81,7 @@ export default function IdInput() {
         })}
         onClick={handleCheckIdDuplicate}
       >
-        {status === 'loading' ? '확인중..' : '중복 확인'}
+        중복 확인
       </button>
     </div>
   );

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -66,8 +66,8 @@ export default function IdInput() {
         {...register('id', {
           required: ERROR_MESSAGE.id,
           validate: {
+            checkValid: (val) => ((val === currentCheckedId) || '아이디 중복확인을 해주세요.'),
             checkError: () => ((status !== 'error') || '이미 사용중인 아이디입니다.'),
-            checkValid: (val) => ((status === 'success' && val === currentCheckedId) || '아이디 중복확인을 해주세요.'),
           },
         })}
       />

--- a/src/pages/Auth/Signup/SignupPage/components/PasswordInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/PasswordInput.tsx
@@ -45,7 +45,7 @@ export default function PasswordInput() {
         {...register('password', {
           required: ERROR_MESSAGE.password,
           minLength: {
-            value: 2,
+            value: 8,
             message: ERROR_MESSAGE.password,
           },
           maxLength: {

--- a/src/pages/Auth/Signup/SignupPage/index.tsx
+++ b/src/pages/Auth/Signup/SignupPage/index.tsx
@@ -47,7 +47,7 @@ export default function SignUpForm() {
 
   const clickSubmit = () => {
     if (isDirty && isValid) {
-      // navigate('/signup/complete', { state: { signUpCheck: true }, replace: true });
+      navigate('/signup/complete', { state: { signUpCheck: true }, replace: true });
     } else {
       navigate('');
     }

--- a/src/pages/Auth/Signup/SignupPage/index.tsx
+++ b/src/pages/Auth/Signup/SignupPage/index.tsx
@@ -13,12 +13,13 @@ import PasswordInput from './components/PasswordInput';
 import PasswordCheckInput from './components/PasswordCheckInput';
 
 const useSignUp = () => {
+  const navigate = useNavigate();
   const signup = (form: SignUpFormData) => {
     register({
       account: form.id,
       email: `${form.email}@${form.emailDomain}`,
       password: form.password,
-    });
+    }).then(() => navigate('/signup/complete', { state: { signUpCheck: true }, replace: true }));
   };
 
   return signup;
@@ -26,7 +27,6 @@ const useSignUp = () => {
 
 export default function SignUpForm() {
   useRouteCheck('termsCheck', '/terms-of-service');
-  const navigate = useNavigate();
   const signup = useSignUp();
 
   const methods = useForm<SignUpFormData>({
@@ -44,14 +44,6 @@ export default function SignUpForm() {
     handleSubmit,
     formState: { isDirty, isValid },
   } = methods;
-
-  const clickSubmit = () => {
-    if (isDirty && isValid) {
-      navigate('/signup/complete', { state: { signUpCheck: true }, replace: true });
-    } else {
-      navigate('');
-    }
-  };
 
   return (
     <div className={styles.template}>
@@ -73,7 +65,6 @@ export default function SignUpForm() {
               type="submit"
               className={styles.form__button}
               disabled={!isDirty || !isValid}
-              onClick={clickSubmit}
             >
               완료
             </button>

--- a/src/pages/Auth/Signup/SignupPage/index.tsx
+++ b/src/pages/Auth/Signup/SignupPage/index.tsx
@@ -3,6 +3,7 @@ import { FormProvider, useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import AuthTitle from 'components/Auth/AuthTitle';
 import Copyright from 'components/Auth/Copyright';
+import { register } from 'api/user';
 import styles from './SignUp.module.scss';
 import useRouteCheck from '../hooks/useRouteCheck';
 import { SignUpFormData } from './entity';
@@ -11,9 +12,22 @@ import EmailInput from './components/EmailInput';
 import PasswordInput from './components/PasswordInput';
 import PasswordCheckInput from './components/PasswordCheckInput';
 
+const useSignUp = () => {
+  const signup = (form: SignUpFormData) => {
+    register({
+      account: form.id,
+      email: `${form.email}@${form.emailDomain}`,
+      password: form.password,
+    });
+  };
+
+  return signup;
+};
+
 export default function SignUpForm() {
   useRouteCheck('termsCheck', '/terms-of-service');
   const navigate = useNavigate();
+  const signup = useSignUp();
 
   const methods = useForm<SignUpFormData>({
     mode: 'onChange',
@@ -33,7 +47,7 @@ export default function SignUpForm() {
 
   const clickSubmit = () => {
     if (isDirty && isValid) {
-      navigate('/signup/complete', { state: { signUpCheck: true }, replace: true });
+      // navigate('/signup/complete', { state: { signUpCheck: true }, replace: true });
     } else {
       navigate('');
     }
@@ -47,7 +61,7 @@ export default function SignUpForm() {
           <form
             className={styles.form}
             // form 제출 api 호출
-            onSubmit={handleSubmit((res) => res)}
+            onSubmit={handleSubmit(signup)}
           >
             <div className={styles.form__title}>회원가입</div>
 

--- a/src/pages/Auth/Signup/SignupPage/index.tsx
+++ b/src/pages/Auth/Signup/SignupPage/index.tsx
@@ -60,7 +60,6 @@ export default function SignUpForm() {
         <FormProvider {...methods}>
           <form
             className={styles.form}
-            // form 제출 api 호출
             onSubmit={handleSubmit(signup)}
           >
             <div className={styles.form__title}>회원가입</div>

--- a/src/pages/Auth/Signup/static/signUp.ts
+++ b/src/pages/Auth/Signup/static/signUp.ts
@@ -4,14 +4,6 @@ interface Domain {
   address: string;
 }
 
-export interface ErrorMessage {
-  id: string;
-  email: string
-  password: string;
-  passwordCheck: string;
-  nickname : string;
-}
-
 const DOMAIN: Domain[] = [
   {
     key: 1,
@@ -50,10 +42,10 @@ const DOMAIN: Domain[] = [
   },
 ];
 
-const ERROR_MESSAGE : ErrorMessage = {
+const ERROR_MESSAGE = {
   id: '아이디 중복확인을 해주세요.',
   email: '존재하지 않는 도메인입니다.',
-  password: '비밀번호는 문자, 숫자, 특수문자를 포함한 2~16자리로 이루어져야합니다.',
+  password: '비밀번호는 문자, 숫자, 특수문자를 포함한 8~16자리로 이루어져야합니다.',
   passwordCheck: '비밀번호가 일치하지 않습니다.',
   nickname: '닉네임은 한글, 영문, 숫자만 가능하며 2-10자리로 이루어져야합니다',
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3241,22 +3241,12 @@ content-type@~1.0.4:
   resolved "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-hex@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/convert-hex/-/convert-hex-0.1.0.tgz#08c04568922c27776b8a2e81a95d393362ea0b65"
-  integrity sha512-w20BOb1PiR/sEJdS6wNrUjF5CSfscZFUp7R9NSlXH8h2wynzXVEPFPJECAnkNylZ+cvf3p7TyRUHggDmrwXT9A==
-
 convert-source-map@^1.4.0, convert-source-map@^1.6.0, convert-source-map@^1.7.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
   integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
-
-convert-string@~0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/convert-string/-/convert-string-0.1.0.tgz#79ce41a9bb0d03bcf72cdc6a8f3c56fbbc64410a"
-  integrity sha512-1KX9ESmtl8xpT2LN2tFnKSbV4NiarbVi8DVb39ZriijvtTklyrT+4dT1wsGMHKD3CJUjXgvJzstm9qL9ICojGA==
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -8266,14 +8256,6 @@ setprototypeof@1.2.0:
   version "1.2.0"
   resolved "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz"
   integrity sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==
-
-sha256@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/sha256/-/sha256-0.2.0.tgz#73a0b418daab7035bff86e8491e363412fc2ab05"
-  integrity sha512-kTWMJUaez5iiT9CcMv8jSq6kMhw3ST0uRdcIWl3D77s6AsLXNXRp3heeqqfu5+Dyfu4hwpQnMzhqHh8iNQxw0w==
-  dependencies:
-    convert-hex "~0.1.0"
-    convert-string "~0.1.0"
 
 shebang-command@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
## [#39] request

회원가입 페이지에 필요한 API를 연결했습니다.

- 회원가입 API 추가
- 아이디 중복확인을 검사했는지 확인하기위한 `useIdDuplicateCheck` hook 추가
- 서버 입력 필드 변경에 맞춰 비밀번호 최소 8자리로 변경
- 로그인 / 회원가입 시 비밀번호 sha256 암호화 제거

마지막 닉네임 변경은 프로젝트 채널에서 이슈가 해결된다면 마저 진행하겠습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes

### Screenshot
![signup](https://user-images.githubusercontent.com/50780281/207107397-0688bfdf-e23c-47ce-a2bc-8849e4905b48.gif)

## precautions
`useIdDuplicateCheck`의 31~33 라인이 불편하다고 생각이 드는데, 해결법을 잘 모르겠습니다.

문제상황은 ID duplicate check **실행 이후** React-Query가 반환하는 `status` 값에 따라 **validation trigger**가 되길 원했는데, `duplicateCheck` -> `trigger` -> `status`의 setState 순으로 진행이 되어 validation이 올바르게 트리거되지 않습니다.

나름 React-Query의 `onSuccess` 콜백을 활용해보고, 프라미스도 추가해보고 했지만 해결되지 않아 결국 `useEffect`의 의존성 배열에 추가하게 되었는데 더 나은 방안이 떠오른다면 알려주세요. (아직까지는 `onSuccess` 콜백에 `setTimeout`을 10ms정도로 주는거밖에 떠오르지 않네요..) 