### PR TITLE
[공통] React Query v3 -> v5 로 버전 업

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "search.exclude": {
+    "**/.node_modules": true,
+    "**/package-lock.json": true,
+    "**/yarn.lock": true,
+  },
+}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make an issue or Contact with this repository leader.
 - Language
   - [TypeScript](https://github.com/typescript-cheatsheets/react)
 - Server State Management Library
-  - [@tanstack/react-query](https://@tanstack/react-query.tanstack.com/overview)
+  - [@tanstack/react-query](https://tanstack.com/query/v5)
 - Routing Library
   - [React Router v6](https://reactrouter.com/docs/en/v6/getting-started/tutorial)
 - Linting Library

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Make an issue or Contact with this repository leader.
 - Language
   - [TypeScript](https://github.com/typescript-cheatsheets/react)
 - Server State Management Library
-  - [React-Query](https://react-query.tanstack.com/overview)
+  - [@tanstack/react-query](https://@tanstack/react-query.tanstack.com/overview)
 - Routing Library
   - [React Router v6](https://reactrouter.com/docs/en/v6/getting-started/tutorial)
 - Linting Library

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@tanstack/react-query": "^5.8.1",
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^13.0.0",
     "@testing-library/user-event": "^13.2.1",
@@ -21,7 +22,6 @@
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.36.1",
     "react-naver-maps": "^0.1.2",
-    "react-query": "^3.39.1",
     "react-router-dom": "^6.3.0",
     "react-scripts": "5.0.1",
     "react-toastify": "^9.0.8",

--- a/src/api/follow/entity.ts
+++ b/src/api/follow/entity.ts
@@ -1,4 +1,4 @@
-import { EmailUser } from 'api/user/entity';
+import { User } from 'api/user/entity';
 import { FollowerInfo } from 'pages/Follow/static/entity';
 
 export interface FollowListParams {
@@ -27,8 +27,8 @@ export interface SentOrReceivedFollowParams {
 export interface SentOrReceivedFollowResponse {
   content: {
     id: number;
-    follower: EmailUser;
-    user: EmailUser;
+    follower: User;
+    user: User;
   }[];
   empty: boolean;
   last: boolean;

--- a/src/api/follow/index.ts
+++ b/src/api/follow/index.ts
@@ -39,6 +39,6 @@ export const recentlyActiveFollow = () => followApi.get<GetFollowListResponse>('
 
 export const getFollowReview = (id: number, pageParam: string) => followApi.get<GetFollowReviewResponse>(`/review/follower/${id}/shops?size=9&${pageParam}`);
 
-export const getDetailReview = (followId: number, placeId: string, pageParam: number) => followApi.get<GetDetailReviewResponse>(`/review/follower/${followId}/shop/${placeId}?${pageParam}`);
+export const getDetailReview = (followId: number, placeId: string) => followApi.get<GetDetailReviewResponse>(`/review/follower/${followId}/shop/${placeId}`);
 
 export const getFollowerReviewCount = (param: GetFollowerReviewCountParam) => followApi.get(`/review/follower/${param.followId}/count`);

--- a/src/api/user/entity.ts
+++ b/src/api/user/entity.ts
@@ -25,7 +25,7 @@ export interface ModifyParams {
   email?: string;
 }
 
-export interface EmailUser {
+export interface User {
   account: string;
   id: number;
   nickname: string;
@@ -45,12 +45,6 @@ export interface EmailUser {
     friendCount: number;
   };
 }
-
-export interface SNSUser extends Omit<EmailUser, 'account' | 'profileImage'> {
-  profileImage?: EmailUser['profileImage'];
-}
-
-export type User = EmailUser | SNSUser;
 
 export interface SendRegisterEmailParams {
   email: string;

--- a/src/api/user/index.ts
+++ b/src/api/user/index.ts
@@ -5,7 +5,6 @@ import {
   LoginResponse,
   ModifyParams,
   RegisterParams,
-  EmailUser,
   SendRegisterEmailParams,
   SendFindEmailParams,
   GetAccountParams,
@@ -15,7 +14,7 @@ import {
 } from './entity';
 import userApi from './userApiClient';
 
-export const register = (param: RegisterParams) => userApi.post<EmailUser>('/', param);
+export const register = (param: RegisterParams) => userApi.post<User>('/', param);
 
 export const checkIdDuplicate = (param: CheckIdDuplicateParams) => userApi.get<User>(`/exists?account=${param.account}`);
 

--- a/src/components/common/LoadingSpinner/LoadingSpinner.module.scss
+++ b/src/components/common/LoadingSpinner/LoadingSpinner.module.scss
@@ -1,0 +1,41 @@
+.loading-wrapper {
+  display: flex;
+  position: relative;
+  justify-content: center;
+  align-items: center;
+  width: 100%;
+  margin: 32px 0;
+}
+
+.loading-div {
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  margin: 8px;
+  border: 8px solid #175c8e;
+  border-radius: 50%;
+  animation: loading-wrapper 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+  border-color: #175c8e transparent transparent;
+}
+
+.loading-wrapper div:nth-child(1) {
+  animation-delay: -0.45s;
+}
+
+.loading-wrapper div:nth-child(2) {
+  animation-delay: -0.3s;
+}
+
+.loading-wrapper div:nth-child(3) {
+  animation-delay: -0.15s;
+}
+
+@keyframes loading-wrapper {
+  0% {
+    transform: rotate(0deg);
+  }
+
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/components/common/LoadingSpinner/index.tsx
+++ b/src/components/common/LoadingSpinner/index.tsx
@@ -1,0 +1,19 @@
+import styles from './LoadingSpinner.module.scss';
+
+interface LoadingSpinnerProps {
+  size: number;
+}
+
+function LoadingSpinner(props: LoadingSpinnerProps) {
+  const { size } = props;
+  return (
+    <div className={styles['loading-wrapper']} style={{ height: size }}>
+      <div className={styles['loading-div']} style={{ width: size, height: size }} />
+      <div className={styles['loading-div']} style={{ width: size, height: size }} />
+      <div className={styles['loading-div']} style={{ width: size, height: size }} />
+      <div className={styles['loading-div']} style={{ width: size, height: size }} />
+    </div>
+  );
+}
+
+export default LoadingSpinner;

--- a/src/components/common/SideNavigation/index.tsx
+++ b/src/components/common/SideNavigation/index.tsx
@@ -46,7 +46,7 @@ export default function SideNavigation(): JSX.Element {
     },
     {
       name: '마이페이지',
-      icon: <SpriteSvg id="my-page" height="24" width="18" />,
+      icon: <SpriteSvg id="my-page" height="24" width="24" />,
       link: auth ? '/profile' : '/login',
     },
     {
@@ -91,7 +91,7 @@ export default function SideNavigation(): JSX.Element {
           {auth ? (
             <li>
               <img
-                // src={auth.profileImage?.url || `${defaultImage}`}
+                src={auth?.profileImage?.url}
                 alt="프로필 이미지"
                 className={styles['bottom-navigation__profile-image']}
               />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import './index.scss';
 import { BrowserRouter } from 'react-router-dom';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { Provider as JotaiProvider } from 'jotai';
 import App from './App';
 import reportWebVitals from './reportWebVitals';

--- a/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
+++ b/src/pages/Auth/Signup/SignupPage/components/IdInput.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react';
 import cn from 'utils/ts/classNames';
 import { ReactComponent as ErrorIcon } from 'assets/svg/auth/error.svg';
 import { useFormContext } from 'react-hook-form';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { checkIdDuplicate } from 'api/user';
 import { ERROR_MESSAGE } from 'pages/Auth/Signup/static/signUp';
 import { AxiosError } from 'axios';
@@ -78,7 +78,7 @@ export default function IdInput() {
             // 서버에서 타입을 같이 전달하고 있어 해당 부분 임시 처리
             checkServerValidation: () => (error?.response?.data.errorMessage?.slice(-23)),
             checkError: () => ((status !== 'error') || '이미 사용중인 아이디입니다.'),
-            checkLoading: () => ((status !== 'loading') || '중복 확인중입니다.'),
+            checkLoading: () => ((status !== 'pending') || '중복 확인중입니다.'),
           },
         })}
       />

--- a/src/pages/Follow/components/FollowReview.tsx
+++ b/src/pages/Follow/components/FollowReview.tsx
@@ -1,5 +1,5 @@
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getDetailReview } from 'api/follow';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { ReactComponent as Arrow } from 'assets/svg/common/arrow.svg';
@@ -17,9 +17,10 @@ interface Props {
 
 const useGetDetailReview = (placeId: string, followerId: number) => {
   const { data } = useInfiniteQuery(
-    ['detail', placeId],
-    ({ pageParam = '' }) => getDetailReview(followerId, placeId, pageParam),
     {
+      queryKey: ['detail', placeId],
+      initialPageParam: '',
+      queryFn: () => getDetailReview(followerId, placeId),
       getNextPageParam: (last) => {
         const len = last.data.content.length;
         if (last.data.empty || last.data.last) return null;

--- a/src/pages/Follow/hooks/useAcceptFollow.ts
+++ b/src/pages/Follow/hooks/useAcceptFollow.ts
@@ -1,13 +1,16 @@
 import { acceptFollow } from 'api/follow';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 // 팔로우 승인 후 받은 요청 목록을 다시 받아와 갱신
 const useAcceptFollow = () => {
   const queryClient = useQueryClient();
-  const { mutate: accept } = useMutation('accept', (id: number) => acceptFollow({ id }), {
+  const { mutate: accept } = useMutation({
+    mutationKey: ['accept'],
+    mutationFn: (id: number) => acceptFollow({ id }),
     onSuccess: () => {
-      queryClient.invalidateQueries('received');
-      queryClient.invalidateQueries('follower');
+      queryClient.invalidateQueries({
+        queryKey: ['received', 'follower'],
+      });
     },
   });
   return accept;

--- a/src/pages/Follow/hooks/useCancelFollow.ts
+++ b/src/pages/Follow/hooks/useCancelFollow.ts
@@ -1,12 +1,16 @@
 import { cancelFollow } from 'api/follow';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useCancelFollow = () => {
   const queryClient = useQueryClient();
-  const { mutate: cancel } = useMutation('cancel', (id: number) => cancelFollow({ id }), {
+
+  const { mutate: cancel } = useMutation({
+    mutationKey: ['cancel'],
+    mutationFn: (id: number) => cancelFollow({ id }),
     onSuccess: () => {
-      queryClient.invalidateQueries('sended');
-      queryClient.invalidateQueries('search');
+      queryClient.invalidateQueries({
+        queryKey: ['sended', 'search'],
+      });
     },
   });
 

--- a/src/pages/Follow/hooks/useDeleteFollow.ts
+++ b/src/pages/Follow/hooks/useDeleteFollow.ts
@@ -1,11 +1,14 @@
 import { deleteFollow } from 'api/follow';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useDeleteFollow = () => {
   const queryClient = useQueryClient();
-  const { mutate: del, data } = useMutation('delete', (account: string) => deleteFollow({ userAccount: account }), {
+
+  const { mutate: del, data } = useMutation({
+    mutationKey: ['delete'],
+    mutationFn: (account: string) => deleteFollow({ userAccount: account }),
     onSuccess: () => {
-      queryClient.invalidateQueries('follower');
+      queryClient.invalidateQueries({ queryKey: ['follower'] });
     },
   });
 

--- a/src/pages/Follow/hooks/useGetFollowList.ts
+++ b/src/pages/Follow/hooks/useGetFollowList.ts
@@ -1,21 +1,21 @@
 import { followList } from 'api/follow';
 import { GetFollowListResponse } from 'api/follow/entity';
 import { useEffect } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 // 친구 목록 가져오기
 const useGetFollowList = () => {
-  const { data, hasNextPage, fetchNextPage } = useInfiniteQuery(
-    'follower',
-    ({ pageParam = '' }) => followList(pageParam),
-    {
-      getNextPageParam: (last) => {
-        const len = last.data.content.length;
-        if (last.data.empty || last.data.last) return null;
-        return `cursor=${last.data.content[len - 1].id}`;
-      },
+  const { data, hasNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['follower'],
+    queryFn: ({ pageParam = '' }) => followList(pageParam),
+    initialPageParam: 'cursor=0',
+    getNextPageParam: (last) => {
+      const len = last.data.content.length;
+      if (last.data.empty || last.data.last) return null;
+      return `cursor=${last.data.content[len - 1].id}`;
     },
-  );
+
+  });
   const flatData: GetFollowListResponse = {
     content: data ? data.pages.flatMap((page) => page.data.content) : [],
     empty: !data || data.pages.every((page) => page.data.empty),

--- a/src/pages/Follow/hooks/useGetFollowerReview.ts
+++ b/src/pages/Follow/hooks/useGetFollowerReview.ts
@@ -1,20 +1,19 @@
 import { getFollowReview } from 'api/follow';
 import { useEffect } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 const useGetFollowerReview = (id: number) => {
-  const { data, hasNextPage, fetchNextPage } = useInfiniteQuery(
-    ['review', id],
-    ({ pageParam = '' }) => getFollowReview(id, pageParam),
-    {
-      getNextPageParam: (last) => {
-        const len = last.data.content.length;
-        if (last.data.empty) return null;
-        // cursor: 마지막으로 조회한 상점 id
-        return `cursor=${last.data.content[len - 1].shopId}`;
-      },
+  const { data, hasNextPage, fetchNextPage } = useInfiniteQuery({
+    queryKey: ['review', id],
+    queryFn: ({ pageParam = '' }) => getFollowReview(id, pageParam),
+    initialPageParam: 'cursor=0',
+    getNextPageParam: (last) => {
+      const len = last.data.content.length;
+      if (last.data.empty) return null;
+      // cursor: 마지막으로 조회한 상점 id
+      return `cursor=${last.data.content[len - 1].shopId}`;
     },
-  );
+  });
   const flatData = {
     content: data ? data.pages.flatMap((page) => page.data.content) : [],
   };

--- a/src/pages/Follow/hooks/useGetFollowerReviewCount.ts
+++ b/src/pages/Follow/hooks/useGetFollowerReviewCount.ts
@@ -1,8 +1,9 @@
 import { getFollowerReviewCount } from 'api/follow';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 const useGetFollowerReviewCount = (followId: number) => {
-  const { data } = useQuery('reviewCount', () => getFollowerReviewCount({ followId }));
+  const { data } = useQuery({ queryKey: ['reviewCount'], queryFn: () => getFollowerReviewCount({ followId }) });
+
   return data;
 };
 

--- a/src/pages/Follow/hooks/useGetRecentlyActiveFollower.ts
+++ b/src/pages/Follow/hooks/useGetRecentlyActiveFollower.ts
@@ -1,9 +1,9 @@
 import { recentlyActiveFollow } from 'api/follow';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 // 최대 15명만 보임, 접속한지 24시가 지나면 사라짐
 const useGetRecentlyActiveFollower = () => {
-  const { data, isLoading } = useQuery('recent', () => recentlyActiveFollow());
+  const { data, isLoading } = useQuery({ queryKey: ['recent'], queryFn: () => recentlyActiveFollow() });
 
   return { data, isLoading };
 };

--- a/src/pages/Follow/hooks/useRequestAndUpdate.ts
+++ b/src/pages/Follow/hooks/useRequestAndUpdate.ts
@@ -1,14 +1,15 @@
 import { requestFollow } from 'api/follow';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import makeToast from 'utils/ts/makeToast';
 
 // 팔로우 요청 후 유저 목록을 다시 받아와 요청중 상태로 변경
 const useRequestAndUpdate = () => {
   const queryClient = useQueryClient();
-  const { mutate: request } = useMutation('request', (account: string) => requestFollow({ userAccount: account }), {
+  const { mutate: request } = useMutation({
+    mutationKey: ['request'],
+    mutationFn: (account: string) => requestFollow({ userAccount: account }),
     onSuccess: () => {
-      queryClient.invalidateQueries('sended');
-      queryClient.invalidateQueries('search');
+      queryClient.invalidateQueries({ queryKey: ['sended', 'search'] });
     },
     onError: () => {
       makeToast('error', '잘못된 친구 정보입니다.');

--- a/src/pages/Follow/hooks/useSearchFriend.ts
+++ b/src/pages/Follow/hooks/useSearchFriend.ts
@@ -1,7 +1,7 @@
 import { searchUsers } from 'api/follow';
 import { SearchUsersResponse } from 'api/follow/entity';
 import { useState, useEffect } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 // useInfinitieQuery로 무한 스크롤 구현, pageParam의 기본값은 undefined
 const useSearchFriend = () => {
@@ -10,6 +10,7 @@ const useSearchFriend = () => {
     queryKey: ['search', keyword],
     queryFn: ({ queryKey: [, target], pageParam = '' }) => searchUsers(target, pageParam),
     enabled: keyword !== '',
+    initialPageParam: 'cursor=0',
     getNextPageParam: (lastPage) => {
       const len = lastPage.data.content.length;
       if (lastPage.data.empty || lastPage.data.last) return null;

--- a/src/pages/Follow/hooks/useSentOrReceivedFollow.ts
+++ b/src/pages/Follow/hooks/useSentOrReceivedFollow.ts
@@ -1,7 +1,7 @@
 import { SentOrReceivedFollowResponse } from 'api/follow/entity';
 import { AxiosResponse } from 'axios';
 import { useEffect } from 'react';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 const useSentOrReceivedFollow = (
   key: string,
@@ -11,7 +11,10 @@ const useSentOrReceivedFollow = (
     data,
     fetchNextPage,
     hasNextPage,
-  } = useInfiniteQuery(key, ({ pageParam = 0 }) => queryFn(pageParam), {
+  } = useInfiniteQuery({
+    queryKey: [key],
+    queryFn: ({ pageParam = 0 }) => queryFn(pageParam),
+    initialPageParam: 0,
     // getNextPageParam은 다음 api를 요청할 때 사용될 pageParam값을 정할 수 있다.
     getNextPageParam: (lastPage) => {
       if (lastPage.data.empty || lastPage.data.last) return null;

--- a/src/pages/Home/components/Map/hooks/useFilterShops.ts
+++ b/src/pages/Home/components/Map/hooks/useFilterShops.ts
@@ -1,5 +1,5 @@
 import useGeolocation from 'utils/hooks/useGeolocation';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { getfilterShops } from 'api/shop';
 import { FilterShopsParams } from 'api/shop/entity';
 import { useAuth } from 'store/auth';
@@ -19,10 +19,12 @@ const useFilterShops = ({
   };
   const {
     isLoading, isError, data, refetch,
-  } = useQuery('filterShops', () => getfilterShops(params, {
-    lat: location?.lat,
-    lng: location?.lng,
-  }), {
+  } = useQuery({
+    queryKey: ['filterShops'],
+    queryFn: () => getfilterShops(params, {
+      lat: location?.lat,
+      lng: location?.lng,
+    }),
     enabled,
   });
 

--- a/src/pages/Inquiry/index.tsx
+++ b/src/pages/Inquiry/index.tsx
@@ -15,23 +15,19 @@ export default function Inquiry(): JSX.Element {
   return (
     <div>
       <div className={styles.container}>
-        {
-          postData && (
-            <div>
-              <Datatable
-                data={postData.content}
-                title={title}
-                subTitle={subTitle}
-                TableTopButton={MyInquiry}
-              />
-              <Pagination
-                totalPage={postData.totalPages}
-                setPage={setPage}
-                page={page}
-              />
-            </div>
-          )
-        }
+        <div>
+          <Datatable
+            data={postData.content}
+            title={title}
+            subTitle={subTitle}
+            TableTopButton={MyInquiry}
+          />
+          <Pagination
+            totalPage={postData.totalPages}
+            setPage={setPage}
+            page={page}
+          />
+        </div>
       </div>
       <nav className={styles.nav}>
         <div className={styles['nav__search-block']}>

--- a/src/pages/MyPage/components/Information/index.tsx
+++ b/src/pages/MyPage/components/Information/index.tsx
@@ -1,10 +1,10 @@
 import defaultImage from 'assets/images/follow/default-image.png';
 import option from 'assets/svg/mypage/option.svg';
 import { Link } from 'react-router-dom';
-import { EmailUser } from 'api/user/entity';
+import { User } from 'api/user/entity';
 import styles from './Information.module.scss';
 
-type Profile = EmailUser & {
+type Profile = User & {
   profileImage?: {
     url: string
   },

--- a/src/pages/MyPage/components/MyPost/index.tsx
+++ b/src/pages/MyPage/components/MyPost/index.tsx
@@ -4,13 +4,10 @@ import styles from './MyPost.module.scss';
 import MobileBoard from '../MobileBoard';
 
 export default function MyPost() {
-  const { isLoading, shops } = useReviwedShops();
-  return (
-    <div>
-      {!isLoading && shops && (
-        <MobileBoard posts={shops} />
-      ) }
-      {!isLoading && !shops && (
+  const { shops } = useReviwedShops();
+
+  if (shops.length <= 0) {
+    return (
       <div className={styles['not-exist']}>
         <span className={styles['not-exist__phrase']}>
           <p>등록된 리뷰가 없어요.</p>
@@ -18,7 +15,10 @@ export default function MyPost() {
         </span>
         <img src={notExist} alt="not-exist" className={styles['not-exist__image']} />
       </div>
-      )}
-    </div>
+    );
+  }
+
+  return (
+    <MobileBoard posts={shops} />
   );
 }

--- a/src/pages/MyPage/hooks/useChangeNickname.ts
+++ b/src/pages/MyPage/hooks/useChangeNickname.ts
@@ -1,14 +1,14 @@
 import { patchNickname } from 'api/mypage';
 import { useRef } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useChangeNickname = () => {
   const nicknameRef = useRef<HTMLInputElement>(null);
   const queryClient = useQueryClient();
-  const changeNickname = useMutation(
-    (nickname:string) => patchNickname(nickname),
-    { onSuccess: () => queryClient.invalidateQueries('profile') },
-  );
+  const changeNickname = useMutation({
+    mutationFn: (nickname:string) => patchNickname(nickname),
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['profile'] }),
+  });
   const onClick = (nickname:string) => {
     changeNickname.mutate(nickname);
   };

--- a/src/pages/MyPage/hooks/useChangeProfile.ts
+++ b/src/pages/MyPage/hooks/useChangeProfile.ts
@@ -1,14 +1,15 @@
 import { patchProfileImage } from 'api/mypage';
 import React, { useState } from 'react';
-import { useMutation, useQueryClient } from 'react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 const useChangeProfile = () => {
   const [image, setImage] = useState<FormData | null>(null);
   const [previewUrl, setUrl] = useState<string | null>(null);
   const queryClient = useQueryClient();
-  const changeImage = useMutation(() => patchProfileImage(image), {
+  const changeImage = useMutation({
+    mutationFn: () => patchProfileImage(image),
     onSuccess: () => {
-      queryClient.invalidateQueries('profile');
+      queryClient.invalidateQueries({ queryKey: ['profile'] });
     },
   });
   const getImageUrl = (file:Blob) => {

--- a/src/pages/MyPage/hooks/useMyProfile.ts
+++ b/src/pages/MyPage/hooks/useMyProfile.ts
@@ -1,22 +1,17 @@
 import { getFollowers } from 'api/mypage';
 import { getMe } from 'api/user';
-import { EmailUser } from 'api/user/entity';
-import { useQuery } from '@tanstack/react-query';
-
-type Profile = EmailUser & {
-  profileImage?: {
-    url: string
-  },
-};
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 const useMyProfile = () => {
-  const { data: profileData, isLoading } = useQuery({ queryKey: ['profile'], queryFn: getMe });
-  const { data: followers } = useQuery({ queryKey: ['myFollowers'], queryFn: getFollowers });
-  const profile:Profile | null = profileData ? profileData.data as EmailUser : null;
-  const getTotal = () => (profileData && 'account' in profileData.data ? profileData.data.userCountResponse.reviewCount : 0);
-  const followerNumber = followers?.data.content.length;
+  const { data: profileData, isLoading } = useSuspenseQuery({ queryKey: ['profile'], queryFn: getMe });
+  const { data: followers } = useSuspenseQuery({ queryKey: ['myFollowers'], queryFn: getFollowers });
+
+  const getTotal = () => profileData.data.userCountResponse.reviewCount;
+
+  const followerNumber = followers.data.content.length;
+
   return {
-    profile, isLoading, getTotal, followerNumber,
+    profile: profileData.data, isLoading, getTotal, followerNumber,
   };
 };
 

--- a/src/pages/MyPage/hooks/useMyProfile.ts
+++ b/src/pages/MyPage/hooks/useMyProfile.ts
@@ -1,7 +1,7 @@
 import { getFollowers } from 'api/mypage';
 import { getMe } from 'api/user';
 import { EmailUser } from 'api/user/entity';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 type Profile = EmailUser & {
   profileImage?: {
@@ -10,8 +10,8 @@ type Profile = EmailUser & {
 };
 
 const useMyProfile = () => {
-  const { data: profileData, isLoading } = useQuery('profile', getMe);
-  const { data: followers } = useQuery('myFollowers', getFollowers);
+  const { data: profileData, isLoading } = useQuery({ queryKey: ['profile'], queryFn: getMe });
+  const { data: followers } = useQuery({ queryKey: ['myFollowers'], queryFn: getFollowers });
   const profile:Profile | null = profileData ? profileData.data as EmailUser : null;
   const getTotal = () => (profileData && 'account' in profileData.data ? profileData.data.userCountResponse.reviewCount : 0);
   const followerNumber = followers?.data.content.length;

--- a/src/pages/MyPage/hooks/useReviewedShops.ts
+++ b/src/pages/MyPage/hooks/useReviewedShops.ts
@@ -1,10 +1,10 @@
 import { getReviewedShops } from 'api/mypage';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 const useReviwedShops = () => {
-  const { isLoading, isError, data } = useQuery({ queryKey: ['reviewedShops'], queryFn: () => getReviewedShops() });
-  const shops = data ? data.data.content : [];
-  return { isLoading, isError, shops };
+  const { isLoading, isError, data } = useSuspenseQuery({ queryKey: ['reviewedShops'], queryFn: () => getReviewedShops() });
+
+  return { isLoading, isError, shops: data.data.content };
 };
 
 export default useReviwedShops;

--- a/src/pages/MyPage/hooks/useReviewedShops.ts
+++ b/src/pages/MyPage/hooks/useReviewedShops.ts
@@ -1,8 +1,8 @@
 import { getReviewedShops } from 'api/mypage';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 const useReviwedShops = () => {
-  const { isLoading, isError, data } = useQuery('reviewedShops', () => getReviewedShops());
+  const { isLoading, isError, data } = useQuery({ queryKey: ['reviewedShops'], queryFn: () => getReviewedShops() });
   const shops = data ? data.data.content : [];
   return { isLoading, isError, shops };
 };

--- a/src/pages/MyPage/hooks/useReviews.ts
+++ b/src/pages/MyPage/hooks/useReviews.ts
@@ -1,8 +1,8 @@
 import { getReviews } from 'api/mypage';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 const useReviwes = (placeId:string) => {
-  const { isLoading, isError, data } = useQuery(['reviews', placeId], () => getReviews(placeId));
+  const { isLoading, isError, data } = useQuery({ queryKey: ['reviews', placeId], queryFn: () => getReviews(placeId) });
   const reviews = data ? data.data.content : [];
   return { isLoading, isError, reviews };
 };

--- a/src/pages/MyPage/hooks/useScraps.ts
+++ b/src/pages/MyPage/hooks/useScraps.ts
@@ -1,10 +1,11 @@
 import { getScraps } from 'api/mypage';
-import { useInfiniteQuery } from 'react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 
 const useScraps = () => {
   const { data, isLoading, fetchNextPage } = useInfiniteQuery({
     queryKey: ['scraps'],
     queryFn: ({ pageParam = 0 }) => getScraps(pageParam),
+    initialPageParam: 0,
     // eslint-disable-next-line consistent-return
     getNextPageParam: (lastResponse, allResponse) => {
       const currentPage = allResponse.length - 1;

--- a/src/pages/MyPage/index.tsx
+++ b/src/pages/MyPage/index.tsx
@@ -1,8 +1,9 @@
 import BottomNavigation from 'components/common/BottomNavigation';
 import SideNavigation from 'components/common/SideNavigation';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import { useState } from 'react';
+import { Suspense, useState } from 'react';
 import { toast } from 'react-toastify';
+import LoadingSpinner from 'components/common/LoadingSpinner';
 import Information from './components/Information';
 import BoardSelector from './components/BoardSelector';
 import BookMark from './components/BookMark';
@@ -36,7 +37,9 @@ export default function MyPage() {
       <div className={styles['my-page']}>
         <Information openModal={openModal} profile={profile} followerNumber={followerNumber} />
         <BoardSelector setBoard={setBoard} board={board} />
-        {board === 'MYPOST' && <MyPost />}
+        <Suspense fallback={<LoadingSpinner size={100} />}>
+          {board === 'MYPOST' && <MyPost />}
+        </Suspense>
         {board === 'BOOKMARK' && <BookMark />}
       </div>
       )}

--- a/src/pages/Notice/index.tsx
+++ b/src/pages/Notice/index.tsx
@@ -13,22 +13,18 @@ export default function Notice(): JSX.Element {
   return (
     <div>
       <div className={styles.container}>
-        {
-          postData && (
-            <div>
-              <Datatable
-                data={postData.content}
-                title={title}
-                subTitle={subTitle}
-              />
-              <Pagination
-                totalPage={postData.totalPages}
-                setPage={setPage}
-                page={page}
-              />
-            </div>
-          )
-        }
+        <div>
+          <Datatable
+            data={postData.content}
+            title={title}
+            subTitle={subTitle}
+          />
+          <Pagination
+            totalPage={postData.totalPages}
+            setPage={setPage}
+            page={page}
+          />
+        </div>
       </div>
       <nav className={styles.nav}>
         <div className={styles['nav__search-block']}>

--- a/src/pages/Post/hooks/usePostList.ts
+++ b/src/pages/Post/hooks/usePostList.ts
@@ -1,10 +1,10 @@
 import getPost from 'api/Post';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 const usePostList = (page: number) => {
   const {
     isLoading, isError, data,
-  } = useQuery(['Post', page], () => getPost(page));
+  } = useQuery({ queryKey: ['Post', page], queryFn: () => getPost(page) });
 
   return {
     isLoading, isError, data,

--- a/src/pages/Post/hooks/usePostList.ts
+++ b/src/pages/Post/hooks/usePostList.ts
@@ -1,10 +1,10 @@
 import getPost from 'api/Post';
-import { useQuery } from '@tanstack/react-query';
+import { useSuspenseQuery } from '@tanstack/react-query';
 
 const usePostList = (page: number) => {
   const {
     isLoading, isError, data,
-  } = useQuery({ queryKey: ['Post', page], queryFn: () => getPost(page) });
+  } = useSuspenseQuery({ queryKey: ['Post', page], queryFn: () => getPost(page) });
 
   return {
     isLoading, isError, data,

--- a/src/pages/Search/hooks/useTrendings.ts
+++ b/src/pages/Search/hooks/useTrendings.ts
@@ -1,10 +1,10 @@
 import { fetchTrendings } from 'api/shop';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 
 const useTrendingList = () => {
   const {
     isLoading, isError, data,
-  } = useQuery('trending', fetchTrendings);
+  } = useQuery({ queryKey: ['trending'], queryFn: fetchTrendings });
   const trendings = data?.data.trendings;
   return {
     isLoading, isError, data: trendings,

--- a/src/pages/SearchDetails/hooks/useFetchAutoComplete.ts
+++ b/src/pages/SearchDetails/hooks/useFetchAutoComplete.ts
@@ -1,5 +1,5 @@
 import useGeolocation from 'utils/hooks/useGeolocation';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { fetchAutoComplete } from 'api/search';
 import { FetchAutoCompleteParams } from 'api/search/entity';
 
@@ -16,7 +16,7 @@ const useFetchAutoComplete = (query: string) => {
 
   const {
     isLoading, isError, data, refetch,
-  } = useQuery(['shop', query], () => fetchAutoComplete(params), { enabled: !!query });
+  } = useQuery({ queryKey: ['shop', query], queryFn: () => fetchAutoComplete(params), enabled: !!query });
 
   const isFetching = isLoading || !(location);
   const shop = data?.data;

--- a/src/pages/SearchDetails/hooks/useFetchShops.ts
+++ b/src/pages/SearchDetails/hooks/useFetchShops.ts
@@ -1,6 +1,6 @@
 import useGeolocation from 'utils/hooks/useGeolocation';
 import useDebounce from 'utils/hooks/useDebounce';
-import { useQuery } from 'react-query';
+import { useQuery } from '@tanstack/react-query';
 import { fetchShops } from 'api/shop';
 import { ShopsParams } from 'api/shop/entity';
 import { useEffect, useMemo } from 'react';
@@ -16,7 +16,9 @@ const useFetchShops = (text: string) => {
 
   const {
     isLoading, isError, data, refetch,
-  } = useQuery(['shop', location], () => fetchShops(params), {
+  } = useQuery({
+    queryKey: ['shop', location],
+    queryFn: () => fetchShops(params),
     enabled: !!location,
   });
 

--- a/src/pages/Setting/Withdrawal/useWithdrawal.ts
+++ b/src/pages/Setting/Withdrawal/useWithdrawal.ts
@@ -1,8 +1,8 @@
-import { useMutation } from 'react-query';
+import { useMutation } from '@tanstack/react-query';
 import { withdrawUser } from 'api/user';
 
 const useWithDrawal = () => {
-  const { mutate: deleteAccount } = useMutation('withdrawUser', () => withdrawUser());
+  const { mutate: deleteAccount } = useMutation({ mutationKey: ['withdrawUser'], mutationFn: () => withdrawUser() });
 
   return deleteAccount;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -1034,7 +1034,7 @@
   dependencies:
     regenerator-runtime "^0.14.0"
 
-"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.5", "@babel/runtime@^7.16.3", "@babel/runtime@^7.18.3", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.18.6"
   resolved "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.6.tgz"
   integrity sha512-t9wi7/AW6XtKahAe20Yw0/mMljKq0B1r2fPdvaAdV/KPDZewFXdaaa6K7lxmZBZ8FBNpCiAT6iHPmd6QO9bKfQ==
@@ -1705,6 +1705,18 @@
     "@svgr/plugin-jsx" "^5.5.0"
     "@svgr/plugin-svgo" "^5.5.0"
     loader-utils "^2.0.0"
+
+"@tanstack/query-core@5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/query-core/-/query-core-5.8.1.tgz#5215a028370d9b2f32e83787a0ea119e2f977996"
+  integrity sha512-Y0enatz2zQXBAsd7XmajlCs+WaitdR7dIFkqz9Xd7HL4KV04JOigWVreYseTmNH7YFSBSC/BJ9uuNp1MAf+GfA==
+
+"@tanstack/react-query@^5.8.1":
+  version "5.8.1"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-query/-/react-query-5.8.1.tgz#22a122016e23a39acd90341954a895980ec21ade"
+  integrity sha512-YMagxS8iNPOLg0pK6WOjdSDlAvWKOf69udLOwQrBVmkC2SRLNLko7elo5Ro3ptlJkXvTVHidxC/h5KGi5bH1XQ==
+  dependencies:
+    "@tanstack/query-core" "5.8.1"
 
 "@testing-library/dom@^8.5.0":
   version "8.17.1"
@@ -2846,11 +2858,6 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
-big-integer@^1.6.16:
-  version "1.6.51"
-  resolved "https://registry.npmjs.org/big-integer/-/big-integer-1.6.51.tgz"
-  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
-
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz"
@@ -2920,20 +2927,6 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
-
-broadcast-channel@^3.4.1:
-  version "3.7.0"
-  resolved "https://registry.npmjs.org/broadcast-channel/-/broadcast-channel-3.7.0.tgz"
-  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
-  dependencies:
-    "@babel/runtime" "^7.7.2"
-    detect-node "^2.1.0"
-    js-sha3 "0.8.0"
-    microseconds "0.2.0"
-    nano-time "1.0.0"
-    oblivious-set "1.0.0"
-    rimraf "3.0.2"
-    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3704,7 +3697,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4, detect-node@^2.1.0:
+detect-node@^2.0.4:
   version "2.1.0"
   resolved "https://registry.npmjs.org/detect-node/-/detect-node-2.1.0.tgz"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -5972,11 +5965,6 @@ js-cookie@^2.2.1:
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
   integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
 
-js-sha3@0.8.0:
-  version "0.8.0"
-  resolved "https://registry.npmjs.org/js-sha3/-/js-sha3-0.8.0.tgz"
-  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
-
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz"
@@ -6333,14 +6321,6 @@ map-obj@^4.0.0:
   resolved "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz"
   integrity sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==
 
-match-sorter@^6.0.2:
-  version "6.3.1"
-  resolved "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz"
-  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-    remove-accents "0.4.2"
-
 mathml-tag-names@^2.1.3:
   version "2.1.3"
   resolved "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz"
@@ -6413,11 +6393,6 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
-
-microseconds@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/microseconds/-/microseconds-0.2.0.tgz"
-  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -6536,13 +6511,6 @@ nano-css@^5.3.1:
     sourcemap-codec "^1.4.8"
     stacktrace-js "^2.0.2"
     stylis "^4.0.6"
-
-nano-time@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/nano-time/-/nano-time-1.0.0.tgz"
-  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
-  dependencies:
-    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -6722,11 +6690,6 @@ object.values@^1.1.0, object.values@^1.1.5:
     call-bind "^1.0.2"
     define-properties "^1.1.3"
     es-abstract "^1.19.1"
-
-oblivious-set@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/oblivious-set/-/oblivious-set-1.0.0.tgz"
-  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -7862,15 +7825,6 @@ react-naver-maps@^0.1.2:
     react-use "^17.3.1"
     suspend-react "^0.0.8"
 
-react-query@^3.39.1:
-  version "3.39.2"
-  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.2.tgz#9224140f0296f01e9664b78ed6e4f69a0cc9216f"
-  integrity sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
-    broadcast-channel "^3.4.1"
-    match-sorter "^6.0.2"
-
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz"
@@ -8132,11 +8086,6 @@ relateurl@^0.2.7:
   resolved "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
-remove-accents@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz"
-  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
-
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/renderkid/-/renderkid-3.0.0.tgz"
@@ -8229,7 +8178,7 @@ reusify@^1.0.4:
   resolved "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -9402,14 +9351,6 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
-
-unload@2.2.0:
-  version "2.2.0"
-  resolved "https://registry.npmjs.org/unload/-/unload-2.2.0.tgz"
-  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
-  dependencies:
-    "@babel/runtime" "^7.6.2"
-    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
## #118 request

React Query 버전을 올립니다.

`useSuspenseQuery` 라는 훅을 사용할 수 있는데, `data?.data` 이런 불필요한 구조들을 전부 없앨 수 있어요 
`T | undefined` 로 추론되던 값이, `<T>`로만 추론되기에, 사용이 편하고, Suspense를 적용하는것도 예제를 드려봤어요.

사용중인 모든 쿼리를 5버전에 맞춰 conflict나 버그가 많이 일어날 수 있으니, 제작한 페이지 꼭 한번씩 확인 부탁드려요.
머지되면 설치도 한번씩 해야할거구요

추가적으로, 검색할 때 방해되는 yarn.lock, node_modules등을 무시할 수 있도록 세팅을 추가했어요

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot