### PR TITLE
Hotfix/#10 EmailUser 타입 관련 오류 수정

### DIFF
--- a/src/api/user/entity.ts
+++ b/src/api/user/entity.ts
@@ -35,8 +35,7 @@ export interface User {
     path: string;
     originalName: string;
     url: string;
-  }
-
+  },
   oauthType: string; // 'KAKAO' | 'NAVER' | 'GOOGLE'
   userType: string; // 'ADMIN' | 'NORMAL'...
   userCountResponse: {

--- a/src/pages/Auth/FindIdPassword/mobile/VerifyCode.tsx
+++ b/src/pages/Auth/FindIdPassword/mobile/VerifyCode.tsx
@@ -22,7 +22,7 @@ export default function VerifyCode({
   const loginOrChangePassword = () => {
     if (isDone) {
       if (param.type === 'id') setOpenModal(true);
-      else if (param.type === 'password') navigate('/find-password/change');
+      else if (param.type === 'password') navigate('/find-password/change-mobile');
     }
   };
   const findUserInfo = async (parameter: CodeInfo) => {

--- a/src/pages/Follow/components/EmptyFriend.tsx
+++ b/src/pages/Follow/components/EmptyFriend.tsx
@@ -1,13 +1,13 @@
 import { ReactComponent as Empty } from 'assets/svg/follow/no-friend.svg';
-import style from './FailToSearch.module.scss';
+import styles from './FailToSearch.module.scss';
 
 export default function EmptyFriend() {
   return (
-    <div className={style.template}>
-      <div className={style.content}>
+    <div className={styles.template}>
+      <div className={styles.content}>
         <p>팔로우한 친구가 없어요.</p>
         <p>새로운 친구를 찾아보세요!</p>
-        <Empty className={style.content__svg} />
+        <Empty className={styles.content__svg} />
       </div>
     </div>
   );

--- a/src/pages/Follow/components/FailToSearch.tsx
+++ b/src/pages/Follow/components/FailToSearch.tsx
@@ -1,10 +1,10 @@
 import { ReactComponent as Astronaut } from 'assets/svg/follow/search-fail.svg';
-import style from './FailToSearch.module.scss';
+import styles from './FailToSearch.module.scss';
 
 export default function FailToSearch() {
   return (
-    <div className={style.template}>
-      <div className={style.content}>
+    <div className={styles.template}>
+      <div className={styles.content}>
         <p>친구를 찾지 못했어요.</p>
         <p>다시 검색해 볼까요?</p>
         <Astronaut />

--- a/src/pages/Follow/components/FollowProfile.tsx
+++ b/src/pages/Follow/components/FollowProfile.tsx
@@ -3,7 +3,7 @@ import { useEffect, useState } from 'react';
 import cn from 'utils/ts/classNames';
 import { useLocation } from 'react-router-dom';
 import { User } from 'api/user/entity';
-import style from './FollowProfile.module.scss';
+import styles from './FollowProfile.module.scss';
 import FollowReview from './FollowReview';
 import useDeleteFollow from '../hooks/useDeleteFollow';
 import useRequestAndUpdate from '../hooks/useRequestAndUpdate';
@@ -34,14 +34,14 @@ export default function FollowProfile() {
   const reviewCount = useGetFollowerReviewCount(id);
 
   return (
-    <div className={style.container}>
-      <div className={style.top}>
-        <div className={style.top__container}>
-          <div className={style.user}>
-            <img alt="유저 프로필 이미지" src={defaultImage} className={style.user__profile} />
-            <div className={style.user__info}>
+    <div className={styles.container}>
+      <div className={styles.top}>
+        <div className={styles.top__container}>
+          <div className={styles.user}>
+            <img alt="유저 프로필 이미지" src={defaultImage} className={styles.user__profile} />
+            <div className={styles.user__info}>
               <div>
-                <span className={cn({ [style['user__info--span']]: true })}>{nickname}</span>
+                <span className={cn({ [styles['user__info--span']]: true })}>{nickname}</span>
               </div>
               <div>
                 @
@@ -50,7 +50,7 @@ export default function FollowProfile() {
             </div>
             <button
               type="button"
-              className={style.user__button}
+              className={styles.user__button}
               onClick={() => (isFollowed && del(account))
                 || (!isFollowed && request(account))}
             >
@@ -59,28 +59,28 @@ export default function FollowProfile() {
                 : '팔로우'}
             </button>
           </div>
-          <div className={style.user__count}>
+          <div className={styles.user__count}>
             <div>
-              <div className={cn({ [style['user__count--font']]: true })}>{userCountResponse.reviewCount}</div>
+              <div className={cn({ [styles['user__count--font']]: true })}>{userCountResponse.reviewCount}</div>
               <div>게시물</div>
             </div>
             <div>
-              <div className={cn({ [style['user__count--font']]: true })}>{userCountResponse.friendCount}</div>
+              <div className={cn({ [styles['user__count--font']]: true })}>{userCountResponse.friendCount}</div>
               <div>팔로워</div>
             </div>
           </div>
         </div>
-        <div className={style.set}>리뷰</div>
+        <div className={styles.set}>리뷰</div>
       </div>
-      <div className={style.count}>
+      <div className={styles.count}>
         총
         {' '}
         {reviewCount && reviewCount.data.count}
         {' '}
         개의 리뷰
       </div>
-      <div className={style.content}>
-        <div className={style.review__list}>
+      <div className={styles.content}>
+        <div className={styles.review__list}>
           {data && data.content.map(
             (item) => (
               <FollowReview

--- a/src/pages/Follow/components/FollowProfile.tsx
+++ b/src/pages/Follow/components/FollowProfile.tsx
@@ -2,7 +2,7 @@ import defaultImage from 'assets/images/follow/default-image.png';
 import { useEffect, useState } from 'react';
 import cn from 'utils/ts/classNames';
 import { useLocation } from 'react-router-dom';
-import { EmailUser } from 'api/user/entity';
+import { User } from 'api/user/entity';
 import style from './FollowProfile.module.scss';
 import FollowReview from './FollowReview';
 import useDeleteFollow from '../hooks/useDeleteFollow';
@@ -25,11 +25,13 @@ const useDeleteState = () => {
 
 export default function FollowProfile() {
   const location = useLocation();
-  const state = location.state as EmailUser;
-  const { data } = useGetFollowerReview(state.id);
+  const {
+    nickname, account, userCountResponse, id,
+  } = location.state as User;
+  const { data } = useGetFollowerReview(id);
   const { del, isFollowed } = useDeleteState();
   const request = useRequestAndUpdate();
-  const reviewCount = useGetFollowerReviewCount(state.id);
+  const reviewCount = useGetFollowerReviewCount(id);
 
   return (
     <div className={style.container}>
@@ -39,18 +41,18 @@ export default function FollowProfile() {
             <img alt="유저 프로필 이미지" src={defaultImage} className={style.user__profile} />
             <div className={style.user__info}>
               <div>
-                <span className={cn({ [style['user__info--span']]: true })}>{state.nickname}</span>
+                <span className={cn({ [style['user__info--span']]: true })}>{nickname}</span>
               </div>
               <div>
                 @
-                {state.account !== undefined ? state.account : 'SNS User'}
+                {account}
               </div>
             </div>
             <button
               type="button"
               className={style.user__button}
-              onClick={() => (isFollowed && del(state.account))
-                || (!isFollowed && request(state.account))}
+              onClick={() => (isFollowed && del(account))
+                || (!isFollowed && request(account))}
             >
               {isFollowed
                 ? '팔로잉'
@@ -59,11 +61,11 @@ export default function FollowProfile() {
           </div>
           <div className={style.user__count}>
             <div>
-              <div className={cn({ [style['user__count--font']]: true })}>{state.userCountResponse.reviewCount}</div>
+              <div className={cn({ [style['user__count--font']]: true })}>{userCountResponse.reviewCount}</div>
               <div>게시물</div>
             </div>
             <div>
-              <div className={cn({ [style['user__count--font']]: true })}>{state.userCountResponse.friendCount}</div>
+              <div className={cn({ [style['user__count--font']]: true })}>{userCountResponse.friendCount}</div>
               <div>팔로워</div>
             </div>
           </div>

--- a/src/pages/Follow/components/FollowReview.tsx
+++ b/src/pages/Follow/components/FollowReview.tsx
@@ -3,7 +3,7 @@ import { getDetailReview } from 'api/follow';
 import useBooleanState from 'utils/hooks/useBooleanState';
 import { ReactComponent as Arrow } from 'assets/svg/common/arrow.svg';
 import cn from 'utils/ts/classNames';
-import style from './FollowReview.module.scss';
+import styles from './FollowReview.module.scss';
 import ListReview from './ListReview';
 
 interface Props {
@@ -38,19 +38,19 @@ export default function FollowReview({
   const [isShow, , , toggle] = useBooleanState(false);
 
   return (
-    <div className={style.container}>
-      <div className={style.content}>
+    <div className={styles.container}>
+      <div className={styles.content}>
         {data
             && (
-              <button type="button" onClick={toggle} className={style.title}>
+              <button type="button" onClick={toggle} className={styles.title}>
                 <div>
-                  <span className={style.title__name}>{name}</span>
-                  <span className={style.title__category}>{category}</span>
+                  <span className={styles.title__name}>{name}</span>
+                  <span className={styles.title__category}>{category}</span>
                 </div>
                 <Arrow className={cn(
                   {
-                    [style.title__arrow]: true,
-                    [style['title__arrow--up']]: isShow,
+                    [styles.title__arrow]: true,
+                    [styles['title__arrow--up']]: isShow,
                   },
                 )}
                 />

--- a/src/pages/Follow/components/Follower.tsx
+++ b/src/pages/Follow/components/Follower.tsx
@@ -1,7 +1,7 @@
 import defaultImage from 'assets/images/follow/default-image.png';
 import cn from 'utils/ts/classNames';
 import { useNavigate } from 'react-router-dom';
-import style from './Follower.module.scss';
+import styles from './Follower.module.scss';
 import useRequestAndUpdate from '../hooks/useRequestAndUpdate';
 import useAcceptFollow from '../hooks/useAcceptFollow';
 import useDeleteFollow from '../hooks/useDeleteFollow';
@@ -42,22 +42,22 @@ export default function Follower({
     }
   } = {
     NONE: {
-      className: style['follower__button--request'],
+      className: styles['follower__button--request'],
       onClick: () => account && request(account),
       text: '팔로우',
     },
     REQUEST_SENT: {
-      className: style['follower__button--cancel'],
+      className: styles['follower__button--cancel'],
       onClick: () => requestId && cancel(requestId),
       text: '요청됨',
     },
     FOLLOWED: {
-      className: style.follower__button,
+      className: styles.follower__button,
       onClick: () => (isMobile ? mobileUnfollow() : del(account)),
       text: '팔로잉',
     },
     REQUEST_RECEIVE: {
-      className: style['follower__button--accept'],
+      className: styles['follower__button--accept'],
       onClick: () => requestId && accept(requestId),
       text: '확인',
     },
@@ -65,12 +65,12 @@ export default function Follower({
   const config = buttonConfigs[followedType];
 
   return (
-    <div className={style.follower} id={`${id}`}>
-      <img className={style.follower__image} src={defaultImage} alt="default" />
-      <div className={style.follower__content}>
+    <div className={styles.follower} id={`${id}`}>
+      <img className={styles.follower__image} src={defaultImage} alt="default" />
+      <div className={styles.follower__content}>
         <button
           type="button"
-          className={cn({ [style['follower__content--nickname']]: true })}
+          className={cn({ [styles['follower__content--nickname']]: true })}
           onClick={() => followedType === 'FOLLOWED' && navigate(`${id}`, {
             state: {
               id,
@@ -100,7 +100,7 @@ export default function Follower({
       {followedType === 'REQUEST_RECEIVE' && requestId && (
       <button
         type="button"
-        className={style.follower__button}
+        className={styles.follower__button}
         onClick={() => reject(requestId)}
       >
         거절

--- a/src/pages/Follow/components/ListReview.tsx
+++ b/src/pages/Follow/components/ListReview.tsx
@@ -1,7 +1,7 @@
 import { ReactComponent as Rating } from 'assets/svg/follow/fill-star.svg';
 import { ReactComponent as EmptyStar } from 'assets/svg/follow/empty-star.svg';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
-import style from './ListReview.module.scss';
+import styles from './ListReview.module.scss';
 
 interface Props {
   createdAt: string;
@@ -14,7 +14,7 @@ export default function ListReview({ createdAt, content, rate }: Props) {
   const fillStarArray = new Array<number>(rate).fill(1);
   const emptyStarArray = new Array<number>(5 - rate).fill(1);
   return (
-    <div className={style.container}>
+    <div className={styles.container}>
       {content}
       <div>
         {createdAt}

--- a/src/pages/Follow/components/MobileUnfollow.tsx
+++ b/src/pages/Follow/components/MobileUnfollow.tsx
@@ -2,7 +2,7 @@ import { createPortal } from 'react-dom';
 import defaultImage from 'assets/images/follow/default-image.png';
 import { UseMutateFunction } from '@tanstack/react-query';
 import { AxiosResponse } from 'axios';
-import style from './MobileUnfollow.module.scss';
+import styles from './MobileUnfollow.module.scss';
 
 interface Props {
   nickname: string;
@@ -16,28 +16,28 @@ export default function MobileUnfollow({
 }: Props) {
   const root = document.body;
   return createPortal(
-    <div className={style.container}>
-      <div className={style.overay} />
-      <div className={style.modal}>
-        <div className={style.modal__content}>
-          <div className={style.modal__notice}>
-            <span className={style.modal__nickname}>{nickname}</span>
+    <div className={styles.container}>
+      <div className={styles.overay} />
+      <div className={styles.modal}>
+        <div className={styles.modal__content}>
+          <div className={styles.modal__notice}>
+            <span className={styles.modal__nickname}>{nickname}</span>
             님과의
             <br />
             팔로우를 취소할까요?
           </div>
-          <img src={defaultImage} alt="프로필" className={style.modal__image} />
+          <img src={defaultImage} alt="프로필" className={styles.modal__image} />
           <div>
             <button
               type="button"
-              className={style.modal__delete}
+              className={styles.modal__delete}
               onClick={() => del(account)}
             >
               팔로우 취소
             </button>
             <button
               type="button"
-              className={style.modal__cancel}
+              className={styles.modal__cancel}
               onClick={toggle}
             >
               취소

--- a/src/pages/Follow/components/Recent.tsx
+++ b/src/pages/Follow/components/Recent.tsx
@@ -1,5 +1,5 @@
 import defaultImage from 'assets/images/follow/default-image.png';
-import style from './Recent.module.scss';
+import styles from './Recent.module.scss';
 
 interface Props {
   nickname: string;
@@ -7,9 +7,9 @@ interface Props {
 
 export default function Recent({ nickname }: Props) {
   return (
-    <div className={style.person}>
-      <img src={defaultImage} alt={nickname} className={style.person__profile} />
-      <span className={style.person__nickname}>{nickname}</span>
+    <div className={styles.person}>
+      <img src={defaultImage} alt={nickname} className={styles.person__profile} />
+      <span className={styles.person__nickname}>{nickname}</span>
     </div>
   );
 }

--- a/src/pages/Follow/index.module.scss
+++ b/src/pages/Follow/index.module.scss
@@ -83,6 +83,11 @@
         background-color: #ffffff;
       }
     }
+
+    &--img {
+      width: 15px;
+      height: 15px;
+    }
   }
 }
 

--- a/src/pages/Follow/index.tsx
+++ b/src/pages/Follow/index.tsx
@@ -3,7 +3,7 @@ import search from 'assets/svg/search/lens.svg';
 import { GetFollowListResponse, SentOrReceivedFollowResponse } from 'api/follow/entity';
 import PreviousButton from 'components/PreviousButton/PreviousButton';
 import cn from 'utils/ts/classNames';
-import style from './index.module.scss';
+import styles from './index.module.scss';
 import FailToSearch from './components/FailToSearch';
 import SearchPage from './components/SearchPage';
 import FollowList from './components/FollowList';
@@ -53,22 +53,22 @@ export default function FollowPage() {
   const { data: follower } = useGetFollowList();
   const { data: recent } = useGetRecentlyActiveFollower();
   return (
-    <div className={style.template}>
-      <div className={style.content}>
-        <div className={style.top}>
-          <div className={style.top__prev}>
+    <div className={styles.template}>
+      <div className={styles.content}>
+        <div className={styles.top}>
+          <div className={styles.top__prev}>
             <PreviousButton />
             <p>친구 목록</p>
           </div>
-          <div className={style.top__search}>
+          <div className={styles.top__search}>
             <input
               type="text"
-              className={cn({ [style['top__search--input']]: true })}
+              className={cn({ [styles['top__search--input']]: true })}
               placeholder="검색어를 입력해주세요."
               onChange={handleInputChange}
               value={keyword}
             />
-            <img className={cn({ [style['top__search--img']]: true })} src={search} alt="search" />
+            <img className={cn({ [styles['top__search--img']]: true })} src={search} alt="search" />
           </div>
         </div>
         {keyword.length === 0
@@ -77,7 +77,7 @@ export default function FollowPage() {
             && sent?.content.length === 0
             && receive?.content.length === 0 ? <EmptyFriend />
             : (
-              <div className={style.container}>
+              <div className={styles.container}>
                 {recent && <FollowList title="최근 접속한 친구" data={filterFollowInfo(recent.data)} />}
                 {follower && <FollowList title="모든 친구" data={filterFollowInfo(follower)} />}
                 {receive && sent && <FollowList title="친구 신청" data={filterSendOrReceiveInfo(receive, true)} sent={filterSendOrReceiveInfo(sent, false)} />}

--- a/src/pages/MyPage/components/MobileBoard/index.tsx
+++ b/src/pages/MyPage/components/MobileBoard/index.tsx
@@ -29,7 +29,7 @@ function Review({
           <span className={styles.store__type}>{category}</span>
         </div>
         <button type="button" id={`open${placeId}`} onClick={() => setOpen(!isOpen)} className={styles.post__opener}>
-          <img src={isOpen ? closeArrow : openArrow} alt="post-opener" />
+          <img src={isOpen ? closeArrow : openArrow} alt="post-opener" className={styles.post__opener} />
         </button>
       </label>
       {!isLoading && reviews.map((review) => (


### PR DESCRIPTION
기존 develop 브랜치를 머지 받아 브랜치를 최신화한 이후 pr 머지를 진행했는데, 최신 develop 브랜치에 EmailUser 타입이 없어진 것으로 보여 오류가 생겼습니다.

이제 sns user도 account를 가지므로 user를 더 이상 sns 유저와 email 유저로 구분할 필요가 없어졌기 때문에 EmailUser를 사용중인 페이지에서 User를 사용하도록 변경했습니다.

비밀번호 찾기 모바일 버전에서 라우팅 경로가 잘못된 것이 있어 수정했습니다.

follow 폴더에 style을 styles로 수정했습니다.


## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot