### PR TITLE
refactor: 친구 요청 시 invalidates 및 알림 기능 추가

### DIFF
--- a/src/pages/Follow/components/FollowProfile.tsx
+++ b/src/pages/Follow/components/FollowProfile.tsx
@@ -32,7 +32,7 @@ export default function FollowProfile() {
   } = location.state as User;
   const { data } = useGetFollowerReview(id);
   const { del, isFollowed } = useDeleteState();
-  const request = useRequestAndUpdate();
+  const request = useRequestAndUpdate(account);
   const reviewCount = useGetFollowerReviewCount(id);
 
   return (
@@ -54,7 +54,7 @@ export default function FollowProfile() {
               type="button"
               className={styles.user__button}
               onClick={() => (isFollowed && del(account))
-                || (!isFollowed && request(account))}
+                || (!isFollowed && request())}
             >
               {isFollowed
                 ? '팔로잉'

--- a/src/pages/Follow/components/Follower.tsx
+++ b/src/pages/Follow/components/Follower.tsx
@@ -27,7 +27,7 @@ interface Props {
 export default function Follower({
   nickname, account, followedType, id, requestId, userCountResponse,
 }: Props) {
-  const request = useRequestAndUpdate();
+  const request = useRequestAndUpdate(account);
   const accept = useAcceptFollow();
   const {
     del, isMobile, mobileUnfollow, value, toggle,
@@ -45,7 +45,7 @@ export default function Follower({
   } = {
     NONE: {
       className: styles['follower__button--request'],
-      onClick: () => account && request(account),
+      onClick: () => account && request(),
       text: '팔로우',
     },
     REQUEST_SENT: {
@@ -100,16 +100,16 @@ export default function Follower({
         {config.text}
       </button>
       {followedType === 'REQUEST_RECEIVE' && requestId && (
-      <button
-        type="button"
-        className={styles.follower__button}
-        onClick={() => reject(requestId)}
-      >
-        거절
-      </button>
+        <button
+          type="button"
+          className={styles.follower__button}
+          onClick={() => reject(requestId)}
+        >
+          거절
+        </button>
       )}
       {value && isMobile
-      && <MobileUnfollow nickname={nickname} del={del} toggle={toggle} account={account} />}
+        && <MobileUnfollow nickname={nickname} del={del} toggle={toggle} account={account} />}
     </div>
   );
 }

--- a/src/pages/Follow/components/Follower.tsx
+++ b/src/pages/Follow/components/Follower.tsx
@@ -32,7 +32,7 @@ export default function Follower({
   const {
     del, isMobile, mobileUnfollow, value, toggle,
   } = useDeleteFollow();
-  const cancel = useCancelFollow();
+  const cancel = useCancelFollow(account);
   const reject = useRejectRequest();
   const navigate = useNavigate();
   const buttonConfigs: {

--- a/src/pages/Follow/hooks/useAcceptFollow.ts
+++ b/src/pages/Follow/hooks/useAcceptFollow.ts
@@ -10,7 +10,10 @@ const useAcceptFollow = () => {
     mutationFn: (id: number) => acceptFollow({ id }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['received', 'follower'],
+        queryKey: ['follower'],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ['received'],
       });
     },
   });

--- a/src/pages/Follow/hooks/useCancelFollow.ts
+++ b/src/pages/Follow/hooks/useCancelFollow.ts
@@ -1,16 +1,21 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 
 import { cancelFollow } from 'api/follow';
+import makeToast from 'utils/ts/makeToast';
 
-const useCancelFollow = () => {
+const useCancelFollow = (account: string) => {
   const queryClient = useQueryClient();
   const { mutate: cancel } = useMutation({
     mutationKey: ['cancel'],
     mutationFn: (id: number) => cancelFollow({ id }),
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ['sent', 'search'],
+        queryKey: ['sent'], // 요청한 목록 refetch
       });
+      queryClient.invalidateQueries({
+        queryKey: ['search'], // 검색 목록 refetch
+      });
+      makeToast('success', `${account}님에 대한 친구요청을 취소했습니다.`);
     },
   });
 

--- a/src/pages/Follow/hooks/useGetFollowerReviewCount.ts
+++ b/src/pages/Follow/hooks/useGetFollowerReviewCount.ts
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getFollowerReviewCount } from 'api/follow';
 
 const useGetFollowerReviewCount = (id: number) => {
-  const { data } = useQuery({ queryKey: ['reviewCount'], queryFn: () => getFollowerReviewCount({ id }) });
+  const { data } = useQuery({ queryKey: ['reviewCount', id], queryFn: () => getFollowerReviewCount({ id }) });
   return data;
 };
 

--- a/src/pages/Follow/hooks/useRequestAndUpdate.ts
+++ b/src/pages/Follow/hooks/useRequestAndUpdate.ts
@@ -4,13 +4,15 @@ import { requestFollow } from 'api/follow';
 import makeToast from 'utils/ts/makeToast';
 
 // 팔로우 요청 후 유저 목록을 다시 받아와 요청중 상태로 변경
-const useRequestAndUpdate = () => {
+const useRequestAndUpdate = (account: string) => {
   const queryClient = useQueryClient();
   const { mutate: request } = useMutation({
-    mutationKey: ['request'],
-    mutationFn: (account: string) => requestFollow({ userAccount: account }),
+    mutationKey: ['request', account],
+    mutationFn: () => requestFollow({ userAccount: account }),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['sent', 'search'] });
+      queryClient.invalidateQueries({ queryKey: ['search'] });
+      queryClient.invalidateQueries({ queryKey: ['sent'] });
+      makeToast('success', `${account}님께 친구 요청을 보냈습니다.`);
     },
     onError: () => {
       makeToast('error', '잘못된 친구 정보입니다.');


### PR DESCRIPTION
친구 요청 시 캐싱값을 무효화하여 검색 목록을 재요청합니다.
언팔로우, 친구 요청 수락, 친구 요청 거절도 똑같이 적용했습니다.

또한 toast를 사용하여 요청 성공을 알려주는 UI를 추가했습니다.

close #210 
## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot
![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/101871802/5e67c99b-ba0e-4722-9ca5-9d2ef8b5f6c5)
