### PR TITLE
fix: 롤링 배너,이벤트 전파, 전체 삭제 이슈 해결

### DIFF
--- a/src/pages/Search/components/RecentItem/RecentItem.module.scss
+++ b/src/pages/Search/components/RecentItem/RecentItem.module.scss
@@ -1,18 +1,19 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
 .item {
+  position: relative;
   text-decoration: none;
 }
 
 .container {
+  position: relative;
   width: 150px;
   display: flex;
   flex-direction: column;
   height: 200px;
   font-size: 14px;
-  border-radius: 10px;
+  border-radius: 4px;
   box-shadow: 1px 1px 20px rgb(0 0 0 / 25%);
-  position: relative;
 
   @include media.media-breakpoint-down(mobile) {
     width: 90vw;
@@ -26,7 +27,7 @@
 .image {
   width: 100%;
   height: 150px;
-  border-radius: 10px;
+  border-radius: 4px;
   position: relative;
 }
 
@@ -44,10 +45,10 @@
   }
 
   &__delete {
-    cursor: pointer;
     position: absolute;
-    top: 5px;
-    right: 5px;
+    top: 8px;
+    right: 8px;
+    cursor: pointer;
   }
 }
 
@@ -56,16 +57,19 @@
   flex-direction: column;
   justify-content: center;
   height: 50px;
-  padding-left: 0.5vw;
+  padding: 0 16px;
+  overflow: hidden;
+
+  &__category {
+    color: #979797;
+    font-size: 14px;
+  }
 
   &__name {
     font-weight: bold;
     overflow: hidden;
     color: black;
-  }
-
-  &__category {
-    color: #979797;
+    font-size: 16px;
   }
 
   @include media.media-breakpoint-down(mobile) {

--- a/src/pages/Search/components/RecentItem/index.tsx
+++ b/src/pages/Search/components/RecentItem/index.tsx
@@ -19,7 +19,7 @@ export default function RecentItem({
   data, index, deleteCard,
 }: Props) {
   const {
-    photoToken, name, category, placeId,
+    category, name, photoToken, placeId,
   } = data;
 
   const { isMobile } = useMediaQuery();
@@ -52,8 +52,9 @@ export default function RecentItem({
                 className={styles.delete}
                 type="button"
                 onClick={() => deleteCard(placeId)}
+                aria-label="삭제"
               >
-                <MobileDeleteIcon className={styles['delete__delete-icon']} />
+                <MobileDeleteIcon />
               </button>
             ) : (
               <div className={styles.cover}>
@@ -61,6 +62,7 @@ export default function RecentItem({
                   className={styles.cover__delete}
                   type="button"
                   onClick={() => deleteCard(placeId)}
+                  aria-label="삭제"
                 >
                   <PcDeleteIcon />
                 </button>

--- a/src/pages/Search/components/RecentItem/index.tsx
+++ b/src/pages/Search/components/RecentItem/index.tsx
@@ -10,19 +10,25 @@ import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './RecentItem.module.scss';
 
 interface Props {
-  data: Card;
+  card: Card;
   index: number;
-  deleteCard: (x: string) => void;
+  deleteCard: (target: Card) => void;
 }
 
 export default function RecentItem({
-  data, index, deleteCard,
+  card, index, deleteCard,
 }: Props) {
   const {
     category, name, photoToken, placeId,
-  } = data;
+  } = card;
 
   const { isMobile } = useMediaQuery();
+
+  const handleDelete = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    event.preventDefault();
+    deleteCard(card);
+  };
 
   if (index < 5) {
     return (
@@ -45,30 +51,30 @@ export default function RecentItem({
               : <div className={styles.description__category}>{category}</div>}
             <div className={styles.description__name}>{name}</div>
           </div>
+        </div>
 
-          {isMobile
-            ? (
+        {isMobile
+          ? (
+            <button
+              className={styles.delete}
+              type="button"
+              onClick={handleDelete}
+              aria-label="삭제"
+            >
+              <MobileDeleteIcon />
+            </button>
+          ) : (
+            <div className={styles.cover}>
               <button
-                className={styles.delete}
+                className={styles.cover__delete}
                 type="button"
-                onClick={() => deleteCard(placeId)}
+                onClick={handleDelete}
                 aria-label="삭제"
               >
-                <MobileDeleteIcon />
+                <PcDeleteIcon />
               </button>
-            ) : (
-              <div className={styles.cover}>
-                <button
-                  className={styles.cover__delete}
-                  type="button"
-                  onClick={() => deleteCard(placeId)}
-                  aria-label="삭제"
-                >
-                  <PcDeleteIcon />
-                </button>
-              </div>
-            )}
-        </div>
+            </div>
+          )}
       </Link>
     );
   } return null;

--- a/src/pages/Search/components/RecentItem/index.tsx
+++ b/src/pages/Search/components/RecentItem/index.tsx
@@ -1,38 +1,71 @@
 import { Link } from 'react-router-dom';
 
 import defaultImage from 'assets/images/search/default-image.png';
-import { ReactComponent as Clock } from 'assets/svg/common/clock.svg';
-import { ReactComponent as Close } from 'assets/svg/common/close.svg';
+import { ReactComponent as ClockIcon } from 'assets/svg/common/clock.svg';
+import { ReactComponent as PcDeleteIcon } from 'assets/svg/common/close.svg';
+import { ReactComponent as MobileDeleteIcon } from 'assets/svg/search/delete.svg';
+import { Card } from 'pages/Search/static/entity';
+import useMediaQuery from 'utils/hooks/useMediaQuery';
 
 import styles from './RecentItem.module.scss';
 
 interface Props {
-  photoToken: string | null,
-  name: string,
-  category: string,
-  placeId: string,
-  index: number,
-  isMobile: boolean,
-  deleteItem: (x: string) => void
+  data: Card;
+  index: number;
+  deleteCard: (x: string) => void;
 }
 
 export default function RecentItem({
-  photoToken, name, category, deleteItem, placeId, index, isMobile,
+  data, index, deleteCard,
 }: Props) {
+  const {
+    photoToken, name, category, placeId,
+  } = data;
+
+  const { isMobile } = useMediaQuery();
+
   if (index < 5) {
     return (
-      <Link to={`/shop/${placeId}`} state={{ placeId }} className={styles.item}>
+      <Link
+        className={styles.item}
+        to={`/shop/${placeId}`}
+        state={{ placeId }}
+      >
         <div className={styles.container}>
-          {!isMobile && <img alt="imageAlt" src={photoToken ?? defaultImage} className={styles.image} />}
+          {!isMobile && (
+            <img
+              alt="imageAlt"
+              src={photoToken ?? defaultImage}
+              className={styles.image}
+            />
+          )}
           <div className={styles.description}>
-            {isMobile ? <Clock /> : <div className={styles.description__category}>{category}</div>}
+            {isMobile
+              ? <ClockIcon />
+              : <div className={styles.description__category}>{category}</div>}
             <div className={styles.description__name}>{name}</div>
           </div>
-          {isMobile ? <button className={styles.delete} type="button" onClick={() => deleteItem(placeId)}>x</button> : (
-            <div className={styles.cover}>
-              <Close onClick={() => deleteItem(placeId)} className={styles.cover__delete} />
-            </div>
-          )}
+
+          {isMobile
+            ? (
+              <button
+                className={styles.delete}
+                type="button"
+                onClick={() => deleteCard(placeId)}
+              >
+                <MobileDeleteIcon className={styles['delete__delete-icon']} />
+              </button>
+            ) : (
+              <div className={styles.cover}>
+                <button
+                  className={styles.cover__delete}
+                  type="button"
+                  onClick={() => deleteCard(placeId)}
+                >
+                  <PcDeleteIcon />
+                </button>
+              </div>
+            )}
         </div>
       </Link>
     );

--- a/src/pages/Search/components/RecentSearches/index.tsx
+++ b/src/pages/Search/components/RecentSearches/index.tsx
@@ -1,36 +1,13 @@
-import { useEffect, useState } from 'react';
-
 import RecentItem from 'pages/Search/components/RecentItem';
-import { Cards } from 'pages/Search/static/entity';
+import useRecentSearches from 'pages/Search/hooks/useRecentSearches';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import cn from 'utils/ts/classNames';
 
 import styles from './RecentSearches.module.scss';
 
 export default function RecentSearches() {
-  const [cards, setCards] = useState<Cards>([]);
+  const { cards, deleteCard, clearStorage } = useRecentSearches();
   const { isMobile } = useMediaQuery();
-
-  useEffect(() => {
-    const recenteSearchData = localStorage.getItem('recent_search');
-    if (!recenteSearchData) {
-      localStorage.setItem('recent_search', '[]');
-    } else {
-      setCards(JSON.parse(recenteSearchData));
-    }
-  }, []);
-
-  useEffect(() => {
-    localStorage.setItem('recent_search', JSON.stringify(cards));
-  }, [cards]);
-
-  const deleteCard = (placeId: string) => {
-    setCards((prev) => prev.filter((item) => item.placeId !== placeId));
-  };
-
-  const clearStorage = () => {
-    setCards([]);
-  };
 
   return (
     <div className={styles.container}>
@@ -51,7 +28,7 @@ export default function RecentSearches() {
             key={card.placeId}
             data={card}
             index={index}
-            deleteCard={deleteCard}
+            deleteCard={() => deleteCard(card)}
           />
         ))}
       </div>

--- a/src/pages/Search/components/RecentSearches/index.tsx
+++ b/src/pages/Search/components/RecentSearches/index.tsx
@@ -1,41 +1,35 @@
 import { useEffect, useState } from 'react';
 
 import RecentItem from 'pages/Search/components/RecentItem';
+import { Cards } from 'pages/Search/static/entity';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 import cn from 'utils/ts/classNames';
 
 import styles from './RecentSearches.module.scss';
 
-type List = {
-  photoToken: string | null,
-  name: string,
-  category: string,
-  placeId: string
-}[];
-
 export default function RecentSearches() {
-  const [list, setlist] = useState<List>();
+  const [cards, setCards] = useState<Cards>([]);
   const { isMobile } = useMediaQuery();
 
   useEffect(() => {
-    if (localStorage.getItem('recent')) {
-      const recentList = localStorage.getItem('recent') as string;
-      setlist(JSON.parse(recentList));
+    const recenteSearchData = localStorage.getItem('recent_search');
+    if (!recenteSearchData) {
+      localStorage.setItem('recent_search', '[]');
+    } else {
+      setCards(JSON.parse(recenteSearchData));
     }
   }, []);
 
-  const clearStorage = () => {
-    localStorage.clear();
-    setlist([]);
+  useEffect(() => {
+    localStorage.setItem('recent_search', JSON.stringify(cards));
+  }, [cards]);
+
+  const deleteCard = (placeId: string) => {
+    setCards((prev) => prev.filter((item) => item.placeId !== placeId));
   };
 
-  // 단일 최근 검색한 상점 삭제
-  const deleteItem = (placeId: string) => {
-    const recent = localStorage.getItem('recent') as string; // 로컬 스토리지에 recent 키 값이 존재할 때만 deleteItem 실행 가능
-    const currentRecentList: List = JSON.parse(recent);
-    const removedRecentList = currentRecentList.filter((item) => item.placeId !== placeId);
-    localStorage.setItem('recent', JSON.stringify(removedRecentList));
-    setlist(removedRecentList);
+  const clearStorage = () => {
+    setCards([]);
   };
 
   return (
@@ -52,16 +46,12 @@ export default function RecentSearches() {
         </button>
       </div>
       <div className={styles.list}>
-        {list && list.map((item, index) => (
+        {cards.map((card, index) => (
           <RecentItem
-            photoToken={item.photoToken ?? null}
-            name={item.name}
-            category={item.category}
-            placeId={item.placeId}
-            key={item.placeId}
-            deleteItem={deleteItem}
+            key={card.placeId}
+            data={card}
             index={index}
-            isMobile={isMobile}
+            deleteCard={deleteCard}
           />
         ))}
       </div>

--- a/src/pages/Search/components/RecentSearches/index.tsx
+++ b/src/pages/Search/components/RecentSearches/index.tsx
@@ -11,24 +11,26 @@ export default function RecentSearches() {
 
   return (
     <div className={styles.container}>
-      <div className={styles.title}>
-        {isMobile
-          ? <div className={styles.title__color}>최근 검색</div>
-          : <div className={styles.title__color}>최근 검색한 식당</div>}
-        <button
-          type="button"
-          onClick={clearStorage}
-          className={cn({ [styles.title__color]: true, [styles['title__color--mobile']]: !isMobile })}
-        >전체 삭제
-        </button>
-      </div>
+      {cards.length > 0 && (
+        <div className={styles.title}>
+          {isMobile
+            ? <div className={styles.title__color}>최근 검색</div>
+            : <div className={styles.title__color}>최근 검색한 식당</div>}
+          <button
+            type="button"
+            onClick={clearStorage}
+            className={cn({ [styles.title__color]: true, [styles['title__color--mobile']]: !isMobile })}
+          >전체 삭제
+          </button>
+        </div>
+      )}
       <div className={styles.list}>
         {cards.map((card, index) => (
           <RecentItem
             key={card.placeId}
-            data={card}
+            card={card}
             index={index}
-            deleteCard={() => deleteCard(card)}
+            deleteCard={deleteCard}
           />
         ))}
       </div>

--- a/src/pages/Search/components/RollingBanner/RollingBanner.module.scss
+++ b/src/pages/Search/components/RollingBanner/RollingBanner.module.scss
@@ -9,7 +9,6 @@ $default: #c4c4c4;
   margin-top: 24px;
   height: 32px;
   width: 100%;
-  font-size: 16px;
 
   @include media.media-breakpoint-down(mobile) {
     margin-left: 10px;
@@ -62,14 +61,22 @@ $default: #c4c4c4;
     border-radius: 15px;
     margin-right: 10px;
     padding: 3px 7px;
-    color: $default;
     border: 1px solid $default;
+
+    &:hover {
+      color: $highlight;
+      border: 1px solid $highlight;
+      background-color: rgba(246 191 84 / 20%);
+    }
+  }
+
+  &__tag-button {
+    color: $default;
+    font-size: 16px;
 
     &:hover {
       cursor: default;
       color: $highlight;
-      border: 1px solid $highlight;
-      background-color: rgba(246 191 84 / 20%);
     }
   }
 }

--- a/src/pages/Search/components/RollingBanner/index.tsx
+++ b/src/pages/Search/components/RollingBanner/index.tsx
@@ -1,13 +1,32 @@
+import { useLocation } from 'react-router-dom';
+
 import useTrendingList from 'pages/Search/hooks/useTrendings';
+import useSearchForm from 'store/text';
 
 import styles from './RollingBanner.module.scss';
 
-function renderTagList(tags: string[]) {
+interface Props {
+  tags: string[]
+}
+
+function TagList({ tags } : Props) {
+  const location = useLocation();
+  const { setText } = useSearchForm(location.pathname);
+
   return (
     <ul className={styles['banner__tag-list']}>
       {tags.map((tag) => (
-        <li className={styles.banner__tag} key={tag}>
-          {`#${tag}`}
+        <li
+          className={styles.banner__tag}
+          key={tag}
+        >
+          <button
+            className={styles['banner__tag-button']}
+            type="button"
+            onClick={() => setText(tag)}
+          >
+            {`# ${tag}`}
+          </button>
         </li>
       ))}
     </ul>
@@ -21,9 +40,9 @@ export default function RollingBanner() {
   return isLoading ? null : (
     <div className={styles.banner}>
       <div className={styles['banner__tag-lists']}>
-        {renderTagList(safeTrendings)}
-        {renderTagList(safeTrendings)}
-        {renderTagList(safeTrendings)}
+        <TagList tags={safeTrendings} />
+        <TagList tags={safeTrendings} />
+        <TagList tags={safeTrendings} />
       </div>
       <div className={styles['banner__left-gradient']} />
       <div className={styles['banner__right-gradient']} />

--- a/src/pages/Search/components/SearchInput/index.tsx
+++ b/src/pages/Search/components/SearchInput/index.tsx
@@ -1,23 +1,24 @@
 /* eslint-disable jsx-a11y/control-has-associated-label */
 import { forwardRef } from 'react';
+import { useLocation } from 'react-router-dom';
 
 import { ReactComponent as DeleteIcon } from 'assets/svg/search/delete.svg';
 import { ReactComponent as LensIcon } from 'assets/svg/search/lens.svg';
+import useSearchForm from 'store/text';
 
 import styles from './SearchInput.module.scss';
 
 interface Props {
-  className: string,
-  value: string,
-  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void
-  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
-  onDelete: () => void;
+  className: string
 }
 
 const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
+  const { className } = props;
+
+  const location = useLocation();
   const {
-    className, value, onChange, onSubmit, onDelete,
-  } = props;
+    text, resetText, handleChange, handleSubmit,
+  } = useSearchForm(location.pathname);
 
   return (
     <div className={className}>
@@ -29,18 +30,18 @@ const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
       >
         <form
           className={styles['search-bar__form']}
-          onSubmit={onSubmit}
+          onSubmit={handleSubmit}
           autoComplete="off"
         >
           <input
             className={styles['search-bar__input']}
             placeholder="검색어를 입력해주세요."
             id="search-bar-input"
-            value={value}
+            value={text}
             ref={ref}
-            onChange={onChange}
+            onChange={handleChange}
           />
-          <button type="button" onClick={onDelete}>
+          <button type="button" onClick={resetText}>
             <DeleteIcon title="삭제" className={styles['search-bar__delete']} />
           </button>
           <button type="submit">

--- a/src/pages/Search/components/SearchInput/index.tsx
+++ b/src/pages/Search/components/SearchInput/index.tsx
@@ -14,8 +14,8 @@ interface Props {
 
 const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
   const { className } = props;
-
   const location = useLocation();
+
   const {
     text, resetText, handleChange, handleSubmit,
   } = useSearchForm(location.pathname);
@@ -41,9 +41,11 @@ const SearchInput = forwardRef<HTMLInputElement, Props>((props, ref) => {
             ref={ref}
             onChange={handleChange}
           />
-          <button type="button" onClick={resetText}>
-            <DeleteIcon title="삭제" className={styles['search-bar__delete']} />
-          </button>
+          {text.length > 0 && (
+            <button type="button" onClick={resetText}>
+              <DeleteIcon title="삭제" className={styles['search-bar__delete']} />
+            </button>
+          )}
           <button type="submit">
             <LensIcon title="검색" className={styles['search-bar__lens']} />
           </button>

--- a/src/pages/Search/components/SuggestionItem/index.tsx
+++ b/src/pages/Search/components/SuggestionItem/index.tsx
@@ -23,16 +23,18 @@ export default function SuggestionItem({ item }: Props) {
   };
 
   return (
-    <button
-      className={styles.suggestion}
-      type="button"
-      onClick={handleClick}
-    >
-      <PinIcon className={styles.suggestion__pin} />
-      <div className={styles.suggestion__title}>
-        {item}
-      </div>
+    <>
+      <button
+        className={styles.suggestion}
+        type="button"
+        onClick={handleClick}
+      >
+        <PinIcon className={styles.suggestion__pin} />
+        <div className={styles.suggestion__title}>
+          {item}
+        </div>
+      </button>
       <DeleteIcon className={styles.suggestion__delete} />
-    </button>
+    </>
   );
 }

--- a/src/pages/Search/components/SuggestionItem/index.tsx
+++ b/src/pages/Search/components/SuggestionItem/index.tsx
@@ -1,3 +1,5 @@
+import { useLocation } from 'react-router-dom';
+
 import { ReactComponent as DeleteIcon } from 'assets/svg/search/delete.svg';
 import { ReactComponent as PinIcon } from 'assets/svg/search/pin.svg';
 import useSearchForm from 'store/text';
@@ -9,7 +11,8 @@ interface Props {
 }
 
 export default function SuggestionItem({ item }: Props) {
-  const { setSearchForm } = useSearchForm('/shop');
+  const location = useLocation();
+  const { setSearchForm } = useSearchForm(location.pathname);
 
   const handleClick = () => {
     setSearchForm((prevSearchForm) => ({

--- a/src/pages/Search/components/Suggestions/index.tsx
+++ b/src/pages/Search/components/Suggestions/index.tsx
@@ -10,16 +10,16 @@ import cn from 'utils/ts/classNames';
 import styles from './Suggestions.module.scss';
 
 interface Props {
-  className: string,
-  text: string,
+  className: string;
+  text: string;
 }
 
 export default function Suggestions({ className, text }: Props) {
   const { isMobile } = useMediaQuery();
   const [isActive, , , toggle] = useBooleanState(false);
 
-  const { shop } = useFetchAutoComplete(text ?? '');
-  const [safeAuto, setSafeAuto] = useState<Array<string>>([]);
+  const { shop } = useFetchAutoComplete(text);
+  const [safeAuto, setSafeAuto] = useState<string[]>([]);
 
   useEffect(() => {
     setSafeAuto((shop && shop.data) ? shop.data.filter((e) => e.includes(text)) : []);

--- a/src/pages/Search/hooks/useRecentSearches.ts
+++ b/src/pages/Search/hooks/useRecentSearches.ts
@@ -1,0 +1,34 @@
+import { useAtom } from 'jotai';
+import { atomWithStorage } from 'jotai/utils';
+
+import { Card, Cards } from 'pages/Search/static/entity';
+
+const recentSearchCardsAtom = atomWithStorage<Cards>('recent_searches', []);
+
+const useRecentSearches = () => {
+  const [cards, setCards] = useAtom(recentSearchCardsAtom);
+
+  const addCard = (newCard: Card) => {
+    setCards((prev) => {
+      const filteredCards = prev.filter((item) => item.placeId !== newCard.placeId);
+      return [newCard, ...filteredCards];
+    });
+  };
+
+  const deleteCard = (targetCard: Card) => {
+    setCards((prev) => prev.filter((item) => item.placeId !== targetCard.placeId));
+  };
+
+  const clearStorage = () => {
+    setCards([]);
+  };
+
+  return {
+    cards,
+    addCard,
+    deleteCard,
+    clearStorage,
+  };
+};
+
+export default useRecentSearches;

--- a/src/pages/Search/index.tsx
+++ b/src/pages/Search/index.tsx
@@ -20,7 +20,7 @@ export default function Search(): JSX.Element {
   const location = useLocation();
   const subText = location.pathname === '/shop' ? SHOP_TEXT : POST_TEXT;
   const {
-    text, handleChange, handleSubmit, isEnter, resetText,
+    text, resetText, isEnter,
   } = useSearchForm(location.pathname);
 
   const inputRef = useRef(null);
@@ -42,11 +42,7 @@ export default function Search(): JSX.Element {
             <div className={styles.search}>
               <SearchInput
                 className={styles.search__input}
-                value={text}
                 ref={inputRef}
-                onChange={handleChange}
-                onSubmit={handleSubmit}
-                onDelete={resetText}
               />
               {isSearching && (
                 <Suggestions

--- a/src/pages/Search/static/entity.ts
+++ b/src/pages/Search/static/entity.ts
@@ -1,0 +1,8 @@
+export interface Card {
+  photoToken: string | null;
+  name: string;
+  category: string;
+  placeId: string;
+}
+
+export interface Cards extends Array<Card> {}

--- a/src/pages/Search/static/entity.ts
+++ b/src/pages/Search/static/entity.ts
@@ -1,8 +1,8 @@
 export interface Card {
-  photoToken: string | null;
-  name: string;
   category: string;
+  name: string;
+  photoToken: string | null;
   placeId: string;
 }
 
-export interface Cards extends Array<Card> {}
+export type Cards = Card[];

--- a/src/pages/SearchDetails/components/SearchItem.tsx
+++ b/src/pages/SearchDetails/components/SearchItem.tsx
@@ -2,79 +2,40 @@ import { useNavigate } from 'react-router-dom';
 
 import { Shop } from 'api/shop/entity';
 import { ReactComponent as NotFoundImageIcon } from 'assets/svg/shop/not-found.svg';
+import { Card } from 'pages/Search/static/entity';
 
 import styles from '../SearchDetails.module.scss';
 
 interface Props {
   shop: Shop;
   pathname: string;
+  addCard: (card: Card) => void;
 }
 
-interface RecentParam {
-  name: string,
-  photoToken: string | null,
-  category: string,
-  placeId: string
-}
-
-const setRecentSearches = ({
-  name, photoToken, category, placeId,
-}: RecentParam) => {
-  // 로컬 스토리지에 최근 검색한 상점 저장
-  const recentList = {
-    photoToken,
-    name,
-    category,
-    placeId,
-  };
-  if (localStorage.getItem('recent')) {
-    let flag = false;
-    const existingRecentList = localStorage.getItem('recent') as string;
-    // 왜 string | null로 추론되는지 모르겠음, 일단 타입 단언함
-    const parsingResult: {
-      photoToken: string,
-      name: string,
-      category: string,
-      placeId: string
-    }[] = JSON.parse(existingRecentList);
-    Object.values(parsingResult).forEach((value) => {
-      if (value.placeId === recentList.placeId) flag = true;
-    });
-    // 기존에 추가했던 가게가 아니면 그대로 추가
-    if (!flag) {
-      const obj = [recentList, ...parsingResult];
-      localStorage.setItem('recent', JSON.stringify(obj));
-    }
-    // 기존에 추가했던 가게면 다시 맨 앞으로 끌어옴
-    if (flag) {
-      const removedList = parsingResult.filter((item) => item.placeId !== recentList.placeId);
-      localStorage.setItem('recent', JSON.stringify([recentList, ...removedList]));
-    }
-  } else {
-    // 처음 저장할 때
-    localStorage.setItem('recent', JSON.stringify([recentList]));
-  }
-};
-export default function SearchItem({ shop, pathname }: Props) {
+export default function SearchItem({ shop, pathname, addCard }: Props) {
   const {
     name, formattedAddress, photoToken, placeId, dist, openNow, category,
   } = shop;
 
   const navigate = useNavigate();
   const distInKm = (dist / 1000).toFixed(1);
-  const onClick = () => {
-    setRecentSearches({
-      name, photoToken, placeId, category,
-    });
+  const handleClick = () => {
+    const card: Card = {
+      category, name, photoToken, placeId,
+    };
+
+    addCard(card);
+
     // 음식점 상세 정보로 이동
     const newPath = pathname.includes('/post') ? `/post/${placeId}` : `/shop/${placeId}`;
     navigate(newPath, { state: { placeId } });
   };
+
   return (
     <button
-      onClick={onClick}
-      type="button"
       className={styles.item}
+      type="button"
+      onClick={handleClick}
     >
       <div className={styles.info}>
         <div className={styles['info-data']}>

--- a/src/pages/SearchDetails/index.tsx
+++ b/src/pages/SearchDetails/index.tsx
@@ -19,7 +19,7 @@ export default function SearchDetails() {
   const { isMobile } = useMediaQuery();
   const location = useLocation();
   const {
-    text, handleChange, handleSubmit, isEnter, submittedText, resetText,
+    text, resetText, isEnter, submittedText,
   } = useSearchForm(location.pathname);
   const {
     isFetching, data: shops, count, isError,
@@ -49,11 +49,7 @@ export default function SearchDetails() {
     <div className={styles.details}>
       <SearchInput
         className={styles.details__search}
-        value={text}
         ref={inputRef}
-        onChange={handleChange}
-        onSubmit={handleSubmit}
-        onDelete={resetText}
       />
       {!isMobile && isSearching && !isEnter && <Suggestions className={styles['related-searches']} text={text} />}
       <div className={styles.details__result}>

--- a/src/pages/SearchDetails/index.tsx
+++ b/src/pages/SearchDetails/index.tsx
@@ -4,6 +4,7 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { Shop } from 'api/shop/entity';
 import SearchInput from 'pages/Search/components/SearchInput';
 import Suggestions from 'pages/Search/components/Suggestions';
+import useRecentSearches from 'pages/Search/hooks/useRecentSearches';
 import useSearchingMode from 'pages/Search/hooks/useSearchingMode';
 import LoadingView from 'pages/SearchDetails/components/LoadingView';
 import SearchItem from 'pages/SearchDetails/components/SearchItem';
@@ -14,6 +15,8 @@ import useMediaQuery from 'utils/hooks/useMediaQuery';
 import styles from './SearchDetails.module.scss';
 
 export default function SearchDetails() {
+  const { addCard } = useRecentSearches();
+
   const inputRef = useRef(null);
   const isSearching = useSearchingMode({ inputRef });
   const { isMobile } = useMediaQuery();
@@ -40,7 +43,11 @@ export default function SearchDetails() {
 
     return shops?.map((shop: Shop) => (
       <div className={styles.details__line} key={shop.placeId}>
-        <SearchItem shop={shop} pathname={location.pathname} />
+        <SearchItem
+          shop={shop}
+          pathname={location.pathname}
+          addCard={addCard}
+        />
       </div>
     ));
   };

--- a/src/store/text.ts
+++ b/src/store/text.ts
@@ -22,10 +22,6 @@ const useSearchForm = (pathname: string) => {
     }));
   };
 
-  const resetText = () => {
-    setSearchForm(initialSearchFormState);
-  };
-
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     if (searchForm.text.trim().length === 0) {
@@ -42,6 +38,17 @@ const useSearchForm = (pathname: string) => {
     }
   };
 
+  const setText = (text: string) => {
+    setSearchForm((prevSearchForm) => ({
+      ...prevSearchForm,
+      text,
+    }));
+  };
+
+  const resetText = () => {
+    setSearchForm(initialSearchFormState);
+  };
+
   return {
     setSearchForm,
     text: searchForm.text,
@@ -49,6 +56,7 @@ const useSearchForm = (pathname: string) => {
     handleSubmit,
     submittedText: searchForm.submittedText,
     isEnter: searchForm.isEnter,
+    setText,
     resetText,
   };
 };

--- a/src/store/text.ts
+++ b/src/store/text.ts
@@ -15,6 +15,17 @@ const useSearchForm = (pathname: string) => {
   const searchFormAtom = pathname === '/shop' ? shopSearchFormAtom : postSearchFormAtom;
   const [searchForm, setSearchForm] = useAtom(searchFormAtom);
 
+  const setText = (text: string) => {
+    setSearchForm((prevSearchForm) => ({
+      ...prevSearchForm,
+      text,
+    }));
+  };
+
+  const resetText = () => {
+    setSearchForm(initialSearchFormState);
+  };
+
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchForm((prevSearchForm) => ({
       ...prevSearchForm,
@@ -38,26 +49,15 @@ const useSearchForm = (pathname: string) => {
     }
   };
 
-  const setText = (text: string) => {
-    setSearchForm((prevSearchForm) => ({
-      ...prevSearchForm,
-      text,
-    }));
-  };
-
-  const resetText = () => {
-    setSearchForm(initialSearchFormState);
-  };
-
   return {
-    setSearchForm,
     text: searchForm.text,
-    handleChange,
-    handleSubmit,
-    submittedText: searchForm.submittedText,
-    isEnter: searchForm.isEnter,
+    setSearchForm,
     setText,
     resetText,
+    handleChange,
+    handleSubmit,
+    isEnter: searchForm.isEnter,
+    submittedText: searchForm.submittedText,
   };
 };
 


### PR DESCRIPTION
## [Copy here issue number] request

<!--
- Write here your development contents 
-->
* 롤링 배너의 인기 키워드 클릭 시 해당 단어 검색창에 추가 기능
* 최근 검색한 목록 x버튼 클릭 시 상점 이동 후 삭제됨
* 최근 검색을 다 지우면 "최근 검색한 식당","전체 삭제"도 없어야 함
문제를 해결하였습니다.

최근 검색했던 가게들 로컬 스토리지 저장 로직 개편하였습니다.

jotai에서 자동으로 로컬 스토리지랑 연동되는 기능 좋네요... 최고...

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot

![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/96577250/06e90bb5-89fb-4ac9-a1ba-6f8749ddaa02)
![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/96577250/5c120cb5-6fd3-4bce-bd87-c56b06c3db30)

### Precautions (main files for this PR ...)

