### PR TITLE
fix: 사이드바 요소 가려지는 문제

### DIFF
--- a/src/assets/svg/search/mobile-delete.svg
+++ b/src/assets/svg/search/mobile-delete.svg
@@ -1,0 +1,4 @@
+<svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="0" y="0" width="20" height="20" fill="transparent" />
+  <path d="M6 6L14 14M6 14L14 6" stroke="#898A8D" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/src/layout/DefaultLayout/DefaultLayout.module.scss
+++ b/src/layout/DefaultLayout/DefaultLayout.module.scss
@@ -1,3 +1,14 @@
+.layout {
+  display: flex;
+  flex-direction: row;
+  height: 100dvh;
+}
+
+.sidebar-space {
+  width: 100px;
+  flex-shrink: 0;
+}
+
 .home {
   display: none;
 }

--- a/src/layout/DefaultLayout/index.tsx
+++ b/src/layout/DefaultLayout/index.tsx
@@ -13,13 +13,14 @@ export default function DefaultLayout(): JSX.Element {
   const location = useLocation();
 
   return (
-    <>
+    <div className={styles.layout}>
+      {!isMobile && <span className={styles['sidebar-space']} />}
       <Outlet />
       <div className={cn({ [styles.home]: location.pathname !== '/' })}>
         <Home />
       </div>
       {!isMobile && <SideNavigation />}
       {isMobile && <BottomNavigation />}
-    </>
+    </div>
   );
 }

--- a/src/pages/Follow/components/FollowProfile.module.scss
+++ b/src/pages/Follow/components/FollowProfile.module.scss
@@ -1,12 +1,16 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
 .container {
-  width: 100vw;
+  width: calc(100vw - 100px);
   height: calc(100vh - 80px);
   display: flex;
   justify-content: center;
   align-items: center;
   flex-direction: column;
+
+  @include media.media-breakpoint-down(mobile) {
+    width: 100vw;
+  }
 }
 
 .top {

--- a/src/pages/Follow/index.module.scss
+++ b/src/pages/Follow/index.module.scss
@@ -1,10 +1,8 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
 .template {
-  display: grid;
-  grid-template-columns: 100px 1fr 100px;
   height: 100vh;
-  width: 100vw;
+  width: calc(100vw - 100px);
   padding-top: 60px;
   box-sizing: border-box;
 

--- a/src/pages/Home/Home.module.scss
+++ b/src/pages/Home/Home.module.scss
@@ -4,7 +4,6 @@
   position: relative;
   width: calc(100vw - 100px);
   height: 100vh;
-  margin-left: 100px;
 
   @include media.media-breakpoint-down(mobile) {
     margin: 0;

--- a/src/pages/Inquiry/Inquire/Inquire.module.scss
+++ b/src/pages/Inquiry/Inquire/Inquire.module.scss
@@ -1,16 +1,21 @@
+@use "src/utils/styles/mediaQuery.scss" as media;
+
 $highlight: #ff7f23;
 
 .container {
-  width: calc(100vw - 104px);
+  width: 100%;
   height: 100vh;
   display: flex;
   justify-content: center;
   flex-direction: row;
-  margin-left: 100px;
+
+  @include media.media-breakpoint-down(mobile) {
+    width: 100%;
+  }
 }
 
 .inner-container {
-  width: 947px;
+  width: 860px;
   margin-top: 80px;
   display: flex;
   flex-direction: row;
@@ -20,6 +25,7 @@ $highlight: #ff7f23;
 .menu {
   width: 168px;
   height: 100%;
+  margin-right: 122px;
 
   &__link {
     display: block;

--- a/src/pages/Inquiry/Inquire/components/InquireForm/InquireForm.module.scss
+++ b/src/pages/Inquiry/Inquire/components/InquireForm/InquireForm.module.scss
@@ -2,7 +2,7 @@ $highlight: #ff7f23;
 $disabled: #c4c4c4;
 
 .container {
-  width: 815px;
+  width: 571px;
   height: 100%;
   display: flex;
   flex-direction: column;

--- a/src/pages/Inquiry/Inquiry/Inquiry.module.scss
+++ b/src/pages/Inquiry/Inquiry/Inquiry.module.scss
@@ -12,16 +12,14 @@ $disabled: #c4c4c4;
   display: flex;
   justify-content: center;
   flex-direction: row;
-  margin-left: 100px;
 
-  // @include media.media-breakpoint-down(mobile) {
-  //   width: 100vw;
-  //   margin-left: 0;
-  // }
+  @include media.media-breakpoint-down(mobile) {
+    width: 100vw;
+  }
 }
 
 .inner-container {
-  width: 947px;
+  max-width: 947px;
   display: flex;
   flex-direction: row;
   justify-content: center;

--- a/src/pages/Search/Search.module.scss
+++ b/src/pages/Search/Search.module.scss
@@ -1,12 +1,13 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
 .container {
-  width: 100%;
+  width: calc(100vw - 100px);
+  max-width: 875px;
   height: 100dvh;
+  margin: 0 auto;
 
-  @include media.media-breakpoint-up(mobile) {
-    max-width: 875px;
-    margin: 0 auto;
+  @include media.media-breakpoint-down(mobile) {
+    width: 100%;
   }
 }
 

--- a/src/pages/Search/components/NotFoundPage/NotFoundPage.module.scss
+++ b/src/pages/Search/components/NotFoundPage/NotFoundPage.module.scss
@@ -1,7 +1,6 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
 .container {
-  margin-left: 100px;
   width: calc(100vw - 100px);
   height: 100dvh;
 

--- a/src/pages/Search/components/RecentItem/RecentItem.module.scss
+++ b/src/pages/Search/components/RecentItem/RecentItem.module.scss
@@ -11,7 +11,6 @@
   height: 220px;
   display: flex;
   flex-direction: column;
-  height: 200px;
   font-size: 14px;
   border-radius: 4px;
   box-shadow: 1px 1px 20px rgb(0 0 0 / 25%);
@@ -69,7 +68,7 @@
   top: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(34 34 34 / 0.3);
+  background-color: rgba(34 34 34 / 30%);
   border-radius: 4px;
   opacity: 0;
 

--- a/src/pages/Search/components/RecentItem/RecentItem.module.scss
+++ b/src/pages/Search/components/RecentItem/RecentItem.module.scss
@@ -1,13 +1,14 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
-.item {
+.container {
   position: relative;
   text-decoration: none;
 }
 
-.container {
+.card {
   position: relative;
-  width: 150px;
+  width: 155px;
+  height: 220px;
   display: flex;
   flex-direction: column;
   height: 200px;
@@ -15,29 +16,61 @@
   border-radius: 4px;
   box-shadow: 1px 1px 20px rgb(0 0 0 / 25%);
 
+  &__image {
+    width: 155px;
+    height: 155px;
+    border-radius: 4px;
+    position: relative;
+  }
+
   @include media.media-breakpoint-down(mobile) {
     width: 90vw;
-    height: 20px;
+    height: 33px;
     box-shadow: none;
-    justify-content: space-between;
     flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
   }
 }
 
-.image {
-  width: 100%;
-  height: 150px;
-  border-radius: 4px;
+.description {
   position: relative;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+  padding: 0 16px;
+  overflow: hidden;
+
+  &__category {
+    color: #979797;
+    font-size: 14px;
+  }
+
+  &__name {
+    overflow: hidden;
+    padding-left: 3px;
+    color: black;
+    font-size: 16px;
+    font-weight: 700;
+  }
+
+  @include media.media-breakpoint-down(mobile) {
+    flex-direction: row;
+    align-items: center;
+    justify-content: start;
+    padding: 0;
+  }
 }
 
 .cover {
-  width: 150px;
-  height: 200px;
-  background-color: rgb(0 0 0 / 50%);
   position: absolute;
   top: 0;
-  border-radius: 10px;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(34 34 34 / 0.3);
+  border-radius: 4px;
   opacity: 0;
 
   &:hover {
@@ -50,35 +83,28 @@
     right: 8px;
     cursor: pointer;
   }
-}
-
-.description {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  height: 50px;
-  padding: 0 16px;
-  overflow: hidden;
-
-  &__category {
-    color: #979797;
-    font-size: 14px;
-  }
-
-  &__name {
-    font-weight: bold;
-    overflow: hidden;
-    color: black;
-    font-size: 16px;
-  }
 
   @include media.media-breakpoint-down(mobile) {
-    flex-direction: row;
-    justify-content: start;
-  }
-}
+    position: static;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: transparent;
+    opacity: 1;
 
-.delete {
-  color: #898a8d;
-  cursor: pointer;
+    &:hover {
+      background-color: #eeeeee;
+    }
+
+    &__delete {
+      position: static;
+      width: 100%;
+      height: 100%;
+      color: #898a8d;
+      cursor: pointer;
+    }
+  }
 }

--- a/src/pages/Search/components/RecentItem/index.tsx
+++ b/src/pages/Search/components/RecentItem/index.tsx
@@ -39,33 +39,19 @@ export default function RecentItem({
         className={styles.item}
         to={newPath}
       >
-        <div className={styles.container}>
-          {!isMobile && (
-            <img
-              alt="imageAlt"
-              src={photoToken ?? defaultImage}
-              className={styles.image}
-            />
-          )}
-          <div className={styles.description}>
-            {isMobile
-              ? <ClockIcon />
-              : <div className={styles.description__category}>{category}</div>}
-            <div className={styles.description__name}>{name}</div>
-          </div>
-        </div>
-
-        {isMobile
-          ? (
-            <button
-              className={styles.delete}
-              type="button"
-              onClick={handleDelete}
-              aria-label="삭제"
-            >
-              <MobileDeleteIcon />
-            </button>
-          ) : (
+        {!isMobile && (
+          <>
+            <div className={styles.container}>
+              <img
+                alt="imageAlt"
+                src={photoToken ?? defaultImage}
+                className={styles.image}
+              />
+              <div className={styles.description}>
+                <div className={styles.description__category}>{category}</div>
+                <div className={styles.description__name}>{name}</div>
+              </div>
+            </div>
             <div className={styles.cover}>
               <button
                 className={styles.cover__delete}
@@ -76,7 +62,27 @@ export default function RecentItem({
                 <PcDeleteIcon />
               </button>
             </div>
-          )}
+          </>
+        )}
+
+        {isMobile && (
+          <>
+            <div className={styles.container}>
+              <div className={styles.description}>
+                <ClockIcon />
+                <div className={styles.description__name}>{name}</div>
+              </div>
+            </div>
+            <button
+              className={styles.delete}
+              type="button"
+              onClick={handleDelete}
+              aria-label="삭제"
+            >
+              <MobileDeleteIcon />
+            </button>
+          </>
+        )}
       </Link>
     );
   } return null;

--- a/src/pages/Search/components/RecentItem/index.tsx
+++ b/src/pages/Search/components/RecentItem/index.tsx
@@ -3,7 +3,7 @@ import { Link, useLocation } from 'react-router-dom';
 import defaultImage from 'assets/images/search/default-image.png';
 import { ReactComponent as ClockIcon } from 'assets/svg/common/clock.svg';
 import { ReactComponent as PcDeleteIcon } from 'assets/svg/common/close.svg';
-import { ReactComponent as MobileDeleteIcon } from 'assets/svg/search/delete.svg';
+import { ReactComponent as MobileDeleteIcon } from 'assets/svg/search/mobile-delete.svg';
 import { Card } from 'pages/Search/static/entity';
 import useMediaQuery from 'utils/hooks/useMediaQuery';
 
@@ -36,16 +36,16 @@ export default function RecentItem({
   if (index < 5) {
     return (
       <Link
-        className={styles.item}
+        className={styles.container}
         to={newPath}
       >
         {!isMobile && (
           <>
-            <div className={styles.container}>
+            <div className={styles.card}>
               <img
                 alt="imageAlt"
                 src={photoToken ?? defaultImage}
-                className={styles.image}
+                className={styles.card__image}
               />
               <div className={styles.description}>
                 <div className={styles.description__category}>{category}</div>
@@ -66,22 +66,22 @@ export default function RecentItem({
         )}
 
         {isMobile && (
-          <>
-            <div className={styles.container}>
-              <div className={styles.description}>
-                <ClockIcon />
-                <div className={styles.description__name}>{name}</div>
-              </div>
+          <div className={styles.card}>
+            <div className={styles.description}>
+              <ClockIcon />
+              <div className={styles.description__name}>{name}</div>
             </div>
-            <button
-              className={styles.delete}
-              type="button"
-              onClick={handleDelete}
-              aria-label="삭제"
-            >
-              <MobileDeleteIcon />
-            </button>
-          </>
+            <div className={styles.cover}>
+              <button
+                className={styles.cover__delete}
+                type="button"
+                onClick={handleDelete}
+                aria-label="삭제"
+              >
+                <MobileDeleteIcon />
+              </button>
+            </div>
+          </div>
         )}
       </Link>
     );

--- a/src/pages/Search/components/SearchInput/SearchInput.module.scss
+++ b/src/pages/Search/components/SearchInput/SearchInput.module.scss
@@ -1,10 +1,5 @@
 @use "src/utils/styles/mediaQuery.scss" as media;
 
-.search {
-  width: 100%;
-  height: 100vh;
-}
-
 .search-bar {
   position: relative;
   display: flex;

--- a/src/pages/Search/components/Suggestions/Suggestions.module.scss
+++ b/src/pages/Search/components/Suggestions/Suggestions.module.scss
@@ -4,13 +4,14 @@
   width: 100%;
   min-height: 98px;
   max-height: 359px;
+  margin: 0 auto;
   overflow: scroll;
   border-radius: 0 0 15px 15px;
   box-shadow: 2px 3px 12px 1px rgba(0 0 0 / 10%);
   background-color: white;
 
-  @include media.media-breakpoint-up(mobile) {
-    margin: 0 auto;
+  @include media.media-breakpoint-down(mobile) {
+    width: 95%;
   }
 }
 

--- a/src/pages/Setting/Mobile/IdChange.tsx
+++ b/src/pages/Setting/Mobile/IdChange.tsx
@@ -31,6 +31,7 @@ export default function IdChange(): JSX.Element {
     isShowModal,
     setIsShowError,
   } = useModifyPassword();
+
   return (
     <div className={styles.layout}>
       <div className={styles.back}>

--- a/src/pages/Setting/Mobile/Setting.module.scss
+++ b/src/pages/Setting/Mobile/Setting.module.scss
@@ -3,6 +3,7 @@ $title: #ff7f23;
 $back: white;
 
 .container {
+  width: 100vw;
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/Setting/PC/PcSetting.module.scss
+++ b/src/pages/Setting/PC/PcSetting.module.scss
@@ -50,9 +50,10 @@ $title: #ff7f23;
 }
 
 .container {
-  justify-content: center;
-  align-items: center;
   display: flex;
+  align-items: center;
+  justify-content: center;
+  width: calc(100vw - 100px);
   height: calc(100vh - 80px);
 }
 

--- a/src/pages/Setting/Withdrawal/Withdrawal.module.scss
+++ b/src/pages/Setting/Withdrawal/Withdrawal.module.scss
@@ -6,9 +6,9 @@ $active: #ff7f23;
 $passive: #c4c4c4;
 
 .template {
+  min-height: 100vh;
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
   justify-content: center;
   align-items: center;
 }


### PR DESCRIPTION
## [Copy here issue number] request

<!--
- Write here your development contents 
-->
* 최근 검색 가게 jsx 구조 개선
* DefaultLayout에 사이드바 공간만큼 뒷 요소 추가

DefaultLayout의 PC 사이드바 공간만큼 요소를 만들어서 사이드바에 검색창이 가려지는 등의 문제를 조금 완화했습니다.
DefaultLayout의 스타일 변경으로 그 위에서 돌아가는 페이지들의 css도 일부분 수정했습니다.
하지만 css의 가이드라인이 없기에 문제를 완전히 해결하지는 못 했습니다.

가로폭을 바꿔가면서 비율이 이상하거나 사이드바에 많이 가려지는 페이지가 있는지 위주로 리뷰해주시면 감사하겠습니다.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot

### Precautions (main files for this PR ...)
![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/96577250/9281be60-abba-44cf-927e-c0d404d65e82)
![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/96577250/eb755a97-027a-4ed6-9801-4529f489dc5c)
![image](https://github.com/BCSDLab/JJBAKSA_FRONT_END/assets/96577250/f9505d26-cc78-4cd3-b032-092782c7f719)


Closes #226 
