### PR TITLE
fix: useFetchShops 무한 호출 문제

### DIFF
--- a/src/pages/SearchDetails/hooks/useFetchShops.ts
+++ b/src/pages/SearchDetails/hooks/useFetchShops.ts
@@ -7,10 +7,9 @@ import { ShopsParams } from 'api/shop/entity';
 import useDebounce from 'utils/hooks/useDebounce';
 import useGeolocation from 'utils/hooks/useGeolocation';
 
+const OPTIONS = { maximumAge: 1000 };
+
 const useFetchShops = (text: string) => {
-  const OPTIONS = {
-    maximumAge: 1000,
-  };
   const { location } = useGeolocation(OPTIONS);
   const debouncedText = useDebounce(text, 500);
 

--- a/src/utils/hooks/useFilterShops.ts
+++ b/src/utils/hooks/useFilterShops.ts
@@ -5,9 +5,8 @@ import { FilterShopsParams } from 'api/shop/entity';
 import { useAuth } from 'store/auth';
 import useGeolocation from 'utils/hooks/useGeolocation';
 
-const OPTIONS = {
-  maximumAge: 1000,
-};
+const OPTIONS = { maximumAge: 1000 };
+
 const useFilterShops = ({
   options_friend, options_nearby, options_scrap,
 }: FilterShopsParams) => {


### PR DESCRIPTION
## [] request

<!--
- Write here your development contents 
-->

useFetchShops를 계속 호출하는 문제가 있어서 원인을 찾아봤는데
컴포넌트 안에서 useGeolocation의 인자로 사용될 상수를 선언하는 것이 원인이었습니다.
이에 상수를 컴포넌트 바깥으로 빼내서 문제를 해결하였습니다.

원래 코드가 호출을 많이 하는 코드이긴 했어도 쿼리키가 변하지는 않았어서
서버에 직접적인 부담은 없었습니다.
그래서 늦게 알아차린 것 같아요.

## Please check if the PR fulfills these requirements

- [x] It's submitted to `develop` branch, __not__ the `main` branch
- [x] The commit message follows our guidelines
- [x] There are no warning message when you run `yarn lint`
- [x] Docs updated for breaking changes


### Screenshot

### Precautions (main files for this PR ...)

Closes #ISSUE_NUMBER
